### PR TITLE
[Translators] Introduce changes and fixes

### DIFF
--- a/src/Bv2IntTranslator.cpp
+++ b/src/Bv2IntTranslator.cpp
@@ -4,14 +4,16 @@
 
 namespace multi_theory_horn {
 
-    Bv2IntTranslator::Bv2IntTranslator(z3::context& c): 
+    Bv2IntTranslator::Bv2IntTranslator(z3::context& c, const VarMap& bv2int_var_map): 
         ctx(c),
-        m_UF_counter(0)
+        m_vars(c),
+        m_UF_counter(0),
+        m_bv2int_var_map(bv2int_var_map)
     {}
 
     void Bv2IntTranslator::reset() {
         m_translate.clear();
-        m_vars.clear();
+        m_lemmas.clear();
     }
 
     bool Bv2IntTranslator::is_special_basic(const z3::expr& e) const {
@@ -44,8 +46,9 @@ namespace multi_theory_horn {
         z3::expr r(ctx);    
         if (e.is_quantifier()) {
             // In case of horn clauses, this shouldn't be reached
-            ASSERT_FALSE("Quantifiers should not be present in CHC BV expressions");
-            r = e; 
+            // This should be unrecahable as quantifiers should not be present
+            // in the CHC BV expressions.
+            UNREACHABLE();
         }
         else if (e.is_var()) {
             // This should be unreachable as we declare variables
@@ -57,12 +60,18 @@ namespace multi_theory_horn {
                 // Note: numerals are handled in translate_bv: Z3_OP_BNUM
                 // Constants are apps with no arguments
                 std::string name = e.decl().name().str();
-                r = ctx.int_const(name.c_str());
+                if (m_bv2int_var_map.find(e.decl()) != m_bv2int_var_map.end()) {
+                    // If we have a mapping for this constant, use it
+                    r = m_bv2int_var_map.at(e.decl());
+                } else {
+                    // Otherwise, create a new integer constant
+                    r = ctx.int_const(name.c_str());
+                }
                 // We only support constants (vars) of Bit-vector sort!
                 assert(e.get_sort().is_bv() && "Expected a BV sort for constant");
                 unsigned k = e.get_sort().bv_size();
                 create_lemma(r, k);
-                m_vars.push_back(key);
+                m_vars.push_back(r);
             }
             else if (is_special_basic(e)) {
                 // Handle special basic cases: ite and eq
@@ -84,6 +93,9 @@ namespace multi_theory_horn {
             }
         }
 
+        // Simplify the result expression
+        // TODO: Make sure the operation doesn't take a lot of time
+        r = r.simplify();
         m_translate.emplace(key, r);
         return r;
     }
@@ -115,7 +127,7 @@ namespace multi_theory_horn {
             case Z3_OP_BADD:
                 k = e.arg(1).get_sort().bv_size();
                 N = (uint64_t)1 << k;
-                r = umod(add(args[0], args[1]), k);
+                r = umod(args[0] + args[1], k);
                 break;
             case Z3_OP_BSUB:
                 k = e.arg(1).get_sort().bv_size();
@@ -125,7 +137,7 @@ namespace multi_theory_horn {
             case Z3_OP_BMUL:
                 k = e.arg(1).get_sort().bv_size();
                 N = (uint64_t)1 << k;
-                r = umod(mul(args[0], args[1]), k);
+                r = umod(args[0] * args[1], k);
                 break;
             
             case Z3_OP_BSDIV:
@@ -171,7 +183,7 @@ namespace multi_theory_horn {
             case Z3_OP_CONCAT:
                 k = e.arg(1).get_sort().bv_size();
                 N = (uint64_t)1 << k;
-                r = add((mul(args[0], ctx.int_val(N))), args[1]);
+                r = (args[0] * ctx.int_val(N)) + args[1];
                 break;
             case Z3_OP_EXTRACT: {
                 // Extract bits from a BV
@@ -202,7 +214,7 @@ namespace multi_theory_horn {
 
             case Z3_OP_BSHL:
                 k = e.arg(1).get_sort().bv_size();
-                r = umod(mul(args[0], pow2(args[1])), k);
+                r = umod(args[0] * pow2(args[1]), k);
                 break;
             case Z3_OP_BLSHR:
                 k = e.arg(1).get_sort().bv_size();
@@ -422,25 +434,15 @@ namespace multi_theory_horn {
         return umod(e / ctx.int_val(N), 1);
     }
 
-    z3::expr Bv2IntTranslator::amod(const z3::expr& e, unsigned k) {
-        // Example: a + (b mod N) mod N = (a + b) mod N
-        uint64_t N = (uint64_t)1 << k;
-        if (e.is_numeral()) {
-            // If e is a numeral, we can compute the modulus directly
-            return ctx.int_val(e.get_numeral_int() % N);
-        }
-
-        return z3::mod(e, ctx.int_val(N));
-    }
-
     z3::expr Bv2IntTranslator::umod(const z3::expr& e, unsigned k) {
         // unsigned modulo N = 2^k
-        return amod(e, k);
+        uint64_t N = (uint64_t)1 << k;
+        return z3::mod(e, ctx.int_val(N));
     }
 
     z3::expr Bv2IntTranslator::uts(const z3::expr& e, unsigned k) {
         // 2 * umod(e, k - 1) - e
-        return (mul(ctx.int_val(2), amod(e, k - 1))) - e;
+        return (ctx.int_val(2) * umod(e, k - 1)) - e;
     }
 
     z3::expr Bv2IntTranslator::pow2(const z3::expr& e) {
@@ -465,48 +467,6 @@ namespace multi_theory_horn {
             }
         }
         return ite(e == ctx.int_val(k), th, el);
-    }
-
-    z3::expr Bv2IntTranslator::mul(const z3::expr& x, const z3::expr& y) {
-        if (x.is_numeral()) {
-            if (x.get_numeral_int() == 0)
-                return ctx.int_val(0);
-            if (x.get_numeral_int() == 1)
-                return y;
-        }
-
-        if (y.is_numeral()) {
-            if (y.get_numeral_int() == 0)
-                return ctx.int_val(0);
-            if (y.get_numeral_int() == 1)
-                return x;
-        }
-
-        if (x.is_numeral() && y.is_numeral()) {
-            // If both are integers, we can use the multiplication directly
-            int mul_result = x.get_numeral_int() * y.get_numeral_int();
-            return ctx.int_val(mul_result);
-        }
-
-        return x * y;
-    }
-
-    z3::expr Bv2IntTranslator::add(const z3::expr& x, const z3::expr& y) {
-        if (x.is_numeral())
-            if (x.get_numeral_int() == 0)
-                return y;
-
-        if (y.is_numeral())
-            if (y.get_numeral_int() == 0)
-                return x;
-
-        if (x.is_numeral() && y.is_numeral()) {
-            // If both are integers, we can use the addition directly
-            int add_result = x.get_numeral_int() + y.get_numeral_int();
-            return ctx.int_val(add_result);
-        }
-
-        return x + y;
     }
 
 } // namespace multi_theory_horn

--- a/src/Bv2IntTranslator.h
+++ b/src/Bv2IntTranslator.h
@@ -1,4 +1,9 @@
+//------------------------------------------------------------------------------
 // Bv2IntTranslator.h
+// A header file for the Bv2IntTranslator class, which translates
+// bit-vector expressions to integer expressions in Z3.
+// Based on the paper: Bit-Precise Reasnoning via Int-Blasting by Zohar et al.
+//------------------------------------------------------------------------------
 
 #pragma once
 #include "utils.h"
@@ -16,7 +21,10 @@ namespace multi_theory_horn {
         // This is used to cache results of translations
         std::unordered_map<Z3_ast, z3::expr, AstHash, AstEq> m_translate;
         // collected BV variables (are collected to later be used to create lemmas)
-        std::vector<Z3_ast> m_vars;
+        z3::expr_vector m_vars;
+        // A map which tells us where to map each variable we find
+        // in the expressions given through the translate method
+        VarMap m_bv2int_var_map;
 
         uint64_t m_UF_counter;
 
@@ -29,10 +37,7 @@ namespace multi_theory_horn {
 
         // Custom implementation of common operations which could simplify
         // the final expression
-        z3::expr amod(const z3::expr& e, unsigned k);
         z3::expr pow2(const z3::expr& e);
-        z3::expr mul(const z3::expr& x, const z3::expr& y);
-        z3::expr add(const z3::expr& x, const z3::expr& y);
         z3::expr if_eq(const z3::expr& e, unsigned k, const z3::expr& th, const z3::expr& el);
 
         // Helper utility functions
@@ -51,14 +56,14 @@ namespace multi_theory_horn {
         z3::expr create_bitwise_uf(const Z3_decl_kind& f, const z3::expr& arg1, const z3::expr& arg2, unsigned k);
         void create_lemma(z3::expr& var, unsigned k);
     public:
-        explicit Bv2IntTranslator(z3::context& c);
+        explicit Bv2IntTranslator(z3::context& c, const VarMap& bv2int_var_map = VarMap());
         void reset();
 
         // Translate any expr; caches results in m_translate
         z3::expr translate(const z3::expr& e);
 
-        // Accessors for the collected vars/preds
-        const std::vector<Z3_ast>& vars() const   { return m_vars; }
+        // Accessors for the collected vars and lemmas
+        z3::expr_vector vars() const   { return m_vars; }
         const std::vector<z3::expr>& lemmas() const { return m_lemmas; }
     };
 } // namespace multi_theory_horn

--- a/src/Int2BvTranslator.h
+++ b/src/Int2BvTranslator.h
@@ -1,4 +1,8 @@
-// Bv2IntTranslator.h
+//------------------------------------------------------------------------------
+// Int2BvTranslator.h
+// A header file for the Int2BvTranslator class, which translates
+// integer expressions to bit-vector expressions in Z3.
+//------------------------------------------------------------------------------
 
 #pragma once
 #include "utils.h"
@@ -14,7 +18,11 @@ namespace multi_theory_horn {
         z3::context&      ctx;
         unsigned          m_bv_size; // Size of the BV type to translate to
         
-        std::vector<Z3_ast> m_vars;
+        z3::expr_vector m_vars;
+        // A map which tells us where to map each variable we find
+        // in the expressions given through the translate method
+        VarMap m_int2bv_var_map;
+
         // This map is used to cache translations
         std::unordered_map<Z3_ast, z3::expr, AstHash, AstEq> m_translate;
 
@@ -27,7 +35,7 @@ namespace multi_theory_horn {
         z3::expr translate_special_basic(const z3::expr& e);
 
     public:
-        explicit Int2BvTranslator(z3::context& c, unsigned bv_size);
+        explicit Int2BvTranslator(z3::context& c, unsigned bv_size, const VarMap& bv2int_var_map = VarMap());
 
         // This must be invoked before starting a new translation
         // It clears the cache and resets the translator state
@@ -37,6 +45,6 @@ namespace multi_theory_horn {
         z3::expr translate(const z3::expr& e);
         
         // Accessors for the collected vars
-        const std::vector<Z3_ast>& vars() const   { return m_vars; }
+        const z3::expr_vector& vars() const { return m_vars; }
     };
 } // namespace multi_theory_horn


### PR DESCRIPTION
- The translator m_vars are now stores as an z3::expr_vector (Might change again in the future)

- We now allow passing an optional expr variable map which tells the translator to use already existing variables

- Remove simplifying functions and use expr simplify() method instead.