### PR TITLE
[bench] Add generate_csv script

### DIFF
--- a/ext/brunch.py
+++ b/ext/brunch.py
@@ -181,8 +181,8 @@ def runTool (tool_args, bench, size, base, out, cpu, mem, fmt, prefix='BRUNCH_ST
     stats = collectStats (stats, outfile, prefix=prefix)
 
     statsLine (statsfile, fmt, stats)
-    if results_csv is not None:
-        statsLine (results_csv, fmt, stats)
+    # if results_csv is not None:
+    #     statsLine (results_csv, fmt, stats)
 
 def main (argv):
     args = parseArgs (argv[1:])
@@ -193,9 +193,9 @@ def main (argv):
     fmt = args.format.split (':')
 
     # Unified results CSV (header written once if missing)
-    results_csv = os.path.join (args.out, 'stats', 'benchmarks_results.csv')
-    if not os.path.exists(results_csv):
-        statsHeader (results_csv, fmt)
+    header_csv = os.path.join (args.out, 'stats', 'header.csv')
+    if not os.path.exists(header_csv):
+        statsHeader (header_csv, fmt)
 
     global cpuTotal
     import resource as r
@@ -233,7 +233,7 @@ def main (argv):
             stats['Status'] = 3
             stats['Cpu']    = '0.00'
             statsLine (statsfile, fmt, stats)
-            statsLine (results_csv, fmt, stats)
+            statsLine (header_csv, fmt, stats)
             continue
 
         runTool (args.tool_args, bench, size, base, args.out,
@@ -241,7 +241,7 @@ def main (argv):
                  mem=args.mem,
                  fmt=fmt,
                  prefix=args.prefix,
-                 results_csv=results_csv)
+                 results_csv=header_csv)
 
     return 0
 

--- a/ext/generate_csv.sh
+++ b/ext/generate_csv.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./merge.sh <header.csv>
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <header.csv>" >&2
+    exit 1
+fi
+
+header_file="$1"
+
+if [[ ! -f "$header_file" ]]; then
+    echo "Error: header file '$header_file' not found" >&2
+    exit 1
+fi
+
+dir="$(dirname "$header_file")"
+output_file="$dir/results.csv"
+
+# Write header to output file
+head -n 1 "$header_file" > "$output_file"
+
+# Append all .stats files in the same folder
+for f in "$dir"/*.stats; do
+    [[ -e "$f" ]] || continue
+    sed -n '1p' "$f" >> "$output_file"
+done
+
+echo "Merged $(ls "$dir"/*.stats | wc -l) .stats files into $output_file"


### PR DESCRIPTION
- Originally, brunch.py created the final result .csv which caused many threads to write simultaneously to the same file which causes lines to get dropped.

- Now, we wait for the run to finish, and run:

./generate_csv.sh <path_to_csv_header>

And a result.csv would be created in the same directory.