### PR TITLE
[AMTH] Add clause analyzer methods

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -104,14 +104,14 @@ check_result max_inv(unsigned int size, bool is_multi) {
     expr bad_phi = !(a == (a ^ ((a ^ y) & ite(ult(a, y), c.bv_val(-1, size), c.bv_val(0, size)))));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: q^{size} --> q
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query); 
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -178,14 +178,14 @@ check_result opposite_signs(unsigned int size, bool is_multi) {
     expr bad_phi = !((a ^ b) < c.bv_val(0,size));
     
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: q^{size} --> q
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -270,14 +270,14 @@ check_result opposite_signs_diff(unsigned int size, bool is_multi) {
     expr bad_phi = !((a ^ b) < c.bv_val(0,size));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query); 
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -355,14 +355,14 @@ check_result opposite_signs_diff2(unsigned int size, bool is_multi) {
     expr bad_phi = !((a ^ b) < c.bv_val(0,size));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -430,14 +430,14 @@ check_result abs_ge(unsigned int size, bool is_multi) {
     expr bad_phi = !(x <= i);
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: p --> p^{size}
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -515,14 +515,14 @@ check_result abs_sum(unsigned int size, bool is_multi) {
     expr bad_phi = (a >= 0) && !(((c.bv_val(1,size) | ite(x >= 0, c.bv_val(0,size), c.bv_val(-1,size))) * x) >= ((c.bv_val(1,size) | ite(y >= 0, c.bv_val(0,size), c.bv_val(-1,size))) * y));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -586,14 +586,14 @@ check_result cond_negate(unsigned int size, bool is_multi) {
     expr bad_phi = (b == ite(i <= x, c.bv_val(1, size), c.bv_val(0, size))) && !(((x ^ (-b)) + b) == -x);
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: q^{size} --> q
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -678,14 +678,14 @@ check_result cond_negate_diff(unsigned int size, bool is_multi) {
     expr bad_phi = !(((a ^ (-b)) + b) > c.bv_val(0,size));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -766,14 +766,14 @@ check_result swap(unsigned int size, bool is_multi) {
     expr bad_phi = (a1 == (a ^ b)) && (b1 == (b ^ a1)) && !ult((a1 ^ b1), b1);
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -857,14 +857,14 @@ check_result swap_sum(unsigned int size, bool is_multi) {
     expr bad_phi = (y1 == (y ^ a)) && (a1 == (a ^ y1)) && !uge((y1 ^ a1), a1);
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -925,14 +925,14 @@ check_result turn_off_rm1(unsigned int size, bool is_multi) {
     expr bad_phi = !((z&(z-(c.bv_val(1,size)))) == c.bv_val(0,size));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: q^{size} --> q
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -1016,14 +1016,14 @@ check_result turn_on_lsb(unsigned int size, bool is_multi) {
     expr bad_phi = !(((a + b) | (c.bv_val(1,size))) == (c.bv_val(1,size)));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: r^{size} --> r
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi);
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -1116,14 +1116,14 @@ check_result max_inv_concat(unsigned int size, bool is_multi) {
     expr bad_phi = !(a2 == (a2 ^ ((a2 ^ y2) & ite(ult(a2, y2), c.bv_val(-1, plus1_size), c.bv_val(0, plus1_size)))));
     
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: q^{size} --> q, r --> r^{size + 1}, s^{size + 1} --> s
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query); 
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -1224,14 +1224,14 @@ check_result opposite_signs_concat(unsigned int size, bool is_multi) {
     expr bad_phi = !((a2 ^ b2) < 0);
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: q^{size} --> q, r --> r^{2*size}, s^{2*size} --> s
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 
@@ -1324,14 +1324,14 @@ check_result abs_concat(unsigned int size, bool is_multi) {
     expr bad_phi = !(((c.bv_val(1,plus1_size) | ite(a2 >= 0, c.bv_val(0,plus1_size), c.bv_val(-1,plus1_size))) * a2) > ((c.bv_val(1,plus1_size) | ite(b2 >= 0, c.bv_val(0,plus1_size), c.bv_val(-1,plus1_size))) * b2));
 
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
     
     if (is_multi) {
         // interface constraints: q^{size} --> q, r --> r^{size + 1}, s^{size + 1} --> s
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
     
@@ -1434,14 +1434,14 @@ check_result cond_negate_concat(unsigned int size, bool is_multi) {
     expr bad_phi = (b == ite(i2 <= x2, c.bv_val(1, d_size), c.bv_val(0, d_size))) && !(((x2 ^ (-b)) + b) == -x2);
     
     check_result result = check_result::unknown;
+    expr query = exists(query_vars, query_pred && bad_phi);
 
     if (is_multi) {
         // interface constraints: q^{size} --> q, r --> r^{2*size}, s^{2*size} --> s
         MT_fixedpoint mtfp(c);
         mtfp.from_solver(fp);
-        result = mtfp.query(query_vars, query_pred, bad_phi); 
+        result = mtfp.query(query);
     } else { // bv only
-        expr query = exists(query_vars, query_pred && bad_phi);
         result = fp.query(query);
     }
 

--- a/benchmarks/legacy/legacy_benchmarks.cpp
+++ b/benchmarks/legacy/legacy_benchmarks.cpp
@@ -34,13 +34,13 @@ bool gno_int2bv_preprocess = false;
 expr bounds(context& c, const expr& e, bool is_signed, unsigned int k) {
     if (is_signed) {
         uint64_t N = (uint64_t)1 << (k - 1);
-        int64_t lower_bound = get_signed_bv_lower_bound(k);
-        int64_t upper_bound = get_signed_bv_upper_bound(k);
+        int64_t lower_bound = utils::get_signed_bv_lower_bound(k);
+        int64_t upper_bound = utils::get_signed_bv_upper_bound(k);
         return (c.int_val(lower_bound) <= e) && (e <= c.int_val(upper_bound));
     }
     assert(k <= 64 && "Bit-vector size too large");
-    uint64_t upper_bound = get_unsigned_bv_upper_bound(k);
-    uint64_t lower_bound = get_unsigned_bv_lower_bound(k);
+    uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(k);
+    uint64_t lower_bound = utils::get_unsigned_bv_lower_bound(k);
     return (c.int_val(lower_bound) <= e) && (e <= c.int_val(upper_bound));
 }
 

--- a/src/Bv2IntTranslator.cpp
+++ b/src/Bv2IntTranslator.cpp
@@ -36,7 +36,7 @@ namespace multi_theory_horn {
 
     bool Bv2IntTranslator::is_bv_relation(const z3::expr& e) const {
         Z3_decl_kind f = e.decl().decl_kind();
-        bool has_bv_arg = any_of(e.args(), [&](z3::expr arg) { return arg.is_bv(); });
+        bool has_bv_arg = utils::any_of(e.args(), [&](z3::expr arg) { return arg.is_bv(); });
         return Z3_OP_ULEQ <= f && f <= Z3_OP_SGT && has_bv_arg;
     }
 
@@ -164,7 +164,7 @@ namespace multi_theory_horn {
                 assert(e.is_numeral() && "Z3_OP_BNUM should only be used with numerals");
                 uint64_t raw = e.get_numeral_uint64();
                 if (m_is_signed) {
-                    int64_t raw_int = sign_extend(raw, e.get_sort().bv_size());
+                    int64_t raw_int = utils::sign_extend(raw, e.get_sort().bv_size());
                     return ctx.int_val(raw_int);
                 }
                 return ctx.int_val(raw);

--- a/src/Bv2IntTranslator.cpp
+++ b/src/Bv2IntTranslator.cpp
@@ -66,9 +66,13 @@ namespace multi_theory_horn {
             UNREACHABLE();
         }
         else if (e.is_var()) {
-            // This should be unreachable as we declare variables
-            // as constants (0-arity apps)
-            UNREACHABLE();
+            // Variables should have a VarMap entry.
+            auto it = m_bv2int_var_map.find(e);
+            assert(it != m_bv2int_var_map.end() && "Variable not found in VarMap");
+            r = it->second;
+            assert(e.get_sort().is_bv() && "Expected a BV sort for constant");
+            unsigned k = e.get_sort().bv_size();
+            create_bound_lemma(r, k);
         }
         else {
             // is_app
@@ -388,9 +392,9 @@ namespace multi_theory_horn {
         // Constants are apps with no arguments
         std::string name = e.decl().name().str();
         z3::expr r(ctx);
-        if (m_bv2int_var_map.find(e.decl()) != m_bv2int_var_map.end()) {
+        if (m_bv2int_var_map.find(e) != m_bv2int_var_map.end()) {
             // If we have a mapping for this constant, use it
-            r = m_bv2int_var_map.at(e.decl());
+            r = m_bv2int_var_map.at(e);
         } else {
             // Otherwise, create a new integer constant
             r = ctx.int_const(name.c_str());

--- a/src/Bv2IntTranslator.h
+++ b/src/Bv2IntTranslator.h
@@ -31,7 +31,6 @@ namespace multi_theory_horn {
         VarMap m_bv2int_var_map;
 
         // A set of lemmas specifying the bounds on variables
-        using VarLemmaMap = std::unordered_map<Z3_ast, z3::expr, AstHash, AstEq>;
         VarLemmaMap m_lemmas;
 
         z3::expr bseli(const z3::expr& e, unsigned i);
@@ -89,5 +88,6 @@ namespace multi_theory_horn {
         // Accessors for the collected vars and lemmas
         z3::expr_vector vars() const   { return m_vars; }
         const VarLemmaMap& lemmas() const { return m_lemmas; }
+        const VarMap& bv2int_var_map() const { return m_bv2int_var_map; }
     };
 } // namespace multi_theory_horn

--- a/src/Bv2IntTranslator.h
+++ b/src/Bv2IntTranslator.h
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 
 #pragma once
-#include "utils.h"
+#include "mth_utils.h"
 #include <z3++.h>
 #include <unordered_map>
 #include <vector>

--- a/src/Int2BvPreprocessor.cpp
+++ b/src/Int2BvPreprocessor.cpp
@@ -94,7 +94,7 @@ namespace multi_theory_horn {
         z3::expr res(m_ctx);
 
         if (m_is_signed) {
-            int64_t lower_bound = get_signed_bv_lower_bound(m_bv_size);
+            int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size);
             switch (e_kind) {
                 case Z3_OP_ADD:
                 case Z3_OP_SUB:
@@ -113,7 +113,7 @@ namespace multi_theory_horn {
             }
         }
         else {
-            uint64_t upper_bound = get_unsigned_bv_upper_bound(m_bv_size);
+            uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(m_bv_size);
             switch (e_kind) {
                 case Z3_OP_ADD:
                     res = (e > m_ctx.int_val(upper_bound));
@@ -164,20 +164,20 @@ namespace multi_theory_horn {
     bool Int2BvPreprocessor::is_const_in_bounds(const z3::expr& const_e) const {
         assert(const_e.is_numeral() && "Expected a constant expression");
         if (m_is_signed) {
-            int64_t lower_bound = get_signed_bv_lower_bound(m_bv_size);
-            int64_t upper_bound = get_signed_bv_upper_bound(m_bv_size);
+            int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size);
+            int64_t upper_bound = utils::get_signed_bv_upper_bound(m_bv_size);
             return const_e.get_numeral_int64() >= lower_bound && const_e.get_numeral_int64() <= upper_bound;
         }
 
-        uint64_t upper_bound = get_unsigned_bv_upper_bound(m_bv_size);
-        uint64_t lower_bound = get_unsigned_bv_lower_bound(m_bv_size);
+        uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(m_bv_size);
+        uint64_t lower_bound = utils::get_unsigned_bv_lower_bound(m_bv_size);
         assert(m_bv_size <= 64 && "Unexpected bv size");
         return const_e.get_numeral_int64() >= lower_bound && const_e.get_numeral_int64() <= upper_bound;
     }
 
     void Int2BvPreprocessor::populate_data_structures(const z3::expr& e) {
         // TODO: Make sure the code below is correct as "and" expressions are nested.
-        int n_conjuncts = get_num_conjuncts(e);
+        int n_conjuncts = utils::get_num_conjuncts(e);
 
         m_const_out_of_bounds.resize(n_conjuncts);
         m_func_app_out_of_bounds.resize(n_conjuncts);
@@ -186,7 +186,7 @@ namespace multi_theory_horn {
         for (int i = 0; i < n_conjuncts; ++i) {
             z3::expr conjunct = (n_conjuncts == 1) ? e : e.arg(i);
             // TODO: Make sure the code below is correct as "or" expressions are nested.
-            int n_disjuncts = get_num_disjuncts(conjunct);
+            int n_disjuncts = utils::get_num_disjuncts(conjunct);
 
             m_const_out_of_bounds[i].resize(n_disjuncts, false);
             m_func_app_out_of_bounds[i].resize(n_disjuncts, z3::expr_vector(m_ctx));

--- a/src/Int2BvPreprocessor.cpp
+++ b/src/Int2BvPreprocessor.cpp
@@ -84,20 +84,6 @@ namespace multi_theory_horn {
         m_literals.clear();
     }
 
-    int Int2BvPreprocessor::calc_num_of_conjuncts(const z3::expr& e) const {
-        if (e.is_and()) {
-            return e.num_args();
-        }
-        return 1;
-    }
-
-    int Int2BvPreprocessor::calc_num_of_disjuncts(const z3::expr& e) const {
-        if (e.is_or()) {
-            return e.num_args();
-        }
-        return 1;
-    }
-
     bool Int2BvPreprocessor::is_const_variable(const z3::expr& e) const {
         // Check if the expression is a variable (0-arity application)
         return e.is_const() && !e.is_numeral() && !e.is_bool();
@@ -190,7 +176,8 @@ namespace multi_theory_horn {
     }
 
     void Int2BvPreprocessor::populate_data_structures(const z3::expr& e) {
-        int n_conjuncts = calc_num_of_conjuncts(e);
+        // TODO: Make sure the code below is correct as "and" expressions are nested.
+        int n_conjuncts = get_num_conjuncts(e);
 
         m_const_out_of_bounds.resize(n_conjuncts);
         m_func_app_out_of_bounds.resize(n_conjuncts);
@@ -198,7 +185,8 @@ namespace multi_theory_horn {
 
         for (int i = 0; i < n_conjuncts; ++i) {
             z3::expr conjunct = (n_conjuncts == 1) ? e : e.arg(i);
-            int n_disjuncts = calc_num_of_disjuncts(conjunct);
+            // TODO: Make sure the code below is correct as "or" expressions are nested.
+            int n_disjuncts = get_num_disjuncts(conjunct);
 
             m_const_out_of_bounds[i].resize(n_disjuncts, false);
             m_func_app_out_of_bounds[i].resize(n_disjuncts, z3::expr_vector(m_ctx));

--- a/src/Int2BvPreprocessor.h
+++ b/src/Int2BvPreprocessor.h
@@ -5,7 +5,7 @@
 //------------------------------------------------------------------------------
 
 #pragma once
-#include "utils.h"
+#include "mth_utils.h"
 #include "InstCombiner.h"
 #include <z3++.h>
 #include <unordered_set>

--- a/src/Int2BvTranslator.cpp
+++ b/src/Int2BvTranslator.cpp
@@ -28,7 +28,7 @@ namespace multi_theory_horn {
 
     bool Int2BvTranslator::is_int_relation(const z3::expr& e) const {
         Z3_decl_kind f = e.decl().decl_kind();
-        bool has_int_arg = any_of(e.args(), [&](z3::expr arg) { return arg.is_int(); });
+        bool has_int_arg = utils::any_of(e.args(), [&](z3::expr arg) { return arg.is_int(); });
         return Z3_OP_LE <= f && f <= Z3_OP_GT && has_int_arg;
     }
 

--- a/src/Int2BvTranslator.cpp
+++ b/src/Int2BvTranslator.cpp
@@ -56,7 +56,7 @@ namespace multi_theory_horn {
                 // Note: numerals are handled in translate_bv: Z3_OP_ANUM
                 // Constants are apps with no arguments
                 std::string name = e.decl().name().str();
-                if (m_int2bv_var_map.find(e.decl()) != m_int2bv_var_map.end()) {
+                if (m_int2bv_var_map.find(e) != m_int2bv_var_map.end()) {
                     // If we have a mapping for this constant use it
                     r = ctx.bv_const(name.c_str(), m_bv_size);
                 } else {

--- a/src/mth_utils.cpp
+++ b/src/mth_utils.cpp
@@ -150,12 +150,12 @@ namespace multi_theory_horn {
     }
 
     static void analyze_clause_body(z3::expr const& body, ClauseAnalysisResult& result) {
-        z3::expr_vector conjuncts = get_conjuncts(body);
+        z3::expr_vector conjuncts = utils::get_conjuncts(body);
         int conjunct_count = conjuncts.size();
         for (int i = 0; i < conjunct_count; ++i) {
             z3::expr conjunct = conjuncts[i];
             // Check if the conjunct is a predicate application
-            if (is_uninterpreted_predicate(conjunct)) {
+            if (utils::is_uninterpreted_predicate(conjunct)) {
                 analyze_uninterpreted_predicate(conjunct, /*is_in_body*/ true, result);
             }
             else {
@@ -166,7 +166,7 @@ namespace multi_theory_horn {
 
     static void analyze_rule(z3::expr const& body, z3::expr const& head, ClauseAnalysisResult& result) {
         analyze_clause_body(body, result);
-        assert(is_uninterpreted_predicate(head) && "The head of a rule must be an uninterpreted predicate");
+        assert(utils::is_uninterpreted_predicate(head) && "The head of a rule must be an uninterpreted predicate");
         analyze_uninterpreted_predicate(head, /*is_in_body*/ false, result);
     }
 
@@ -197,6 +197,9 @@ namespace multi_theory_horn {
         result.bv_size = common_bv_size;
     }
 
+    //==============================================================================
+    //                              PUBLIC METHODS
+    //==============================================================================
     z3::expr_vector get_clause_vars(z3::expr const& clause) {
         z3::context& c = clause.ctx();
         z3::expr_vector vars(c);
@@ -244,7 +247,6 @@ namespace multi_theory_horn {
     // ====================================================================
     // MTHFixedpointSet methods
     // ====================================================================
-
     bool MTHFixedpointSet::check_and_set_signedness(bool incoming_sign) {
         if (!global_is_signed.has_value()) {
             global_is_signed = incoming_sign;
@@ -333,7 +335,6 @@ namespace multi_theory_horn {
     // ====================================================================
     // ClauseAnalysisResult methods
     // ====================================================================
-
     std::ostream& operator<<(std::ostream& os, const ClauseAnalysisResult& result) {
         os << "Clause Analysis Result:" << std::endl;
         os << "  Signedness: ";

--- a/src/mth_utils.cpp
+++ b/src/mth_utils.cpp
@@ -1,0 +1,282 @@
+#include "mth_utils.h"
+
+namespace multi_theory_horn {
+
+    static int get_num_conjuncts(const z3::expr& e) {
+        if (e.is_and()) {
+            return e.num_args();
+        }
+        return 1;
+    }
+
+    static bool is_uninterpreted_predicate(const z3::expr& e) {
+        return e.decl().decl_kind() == Z3_OP_UNINTERPRETED;
+    }
+
+    static bool is_signed_bv_op(Z3_decl_kind k) {
+        switch (k) {
+            case Z3_OP_SLEQ:
+            case Z3_OP_SGEQ:
+            case Z3_OP_SLT:
+            case Z3_OP_SGT:
+            case Z3_OP_BSDIV:
+            case Z3_OP_BSREM:
+            case Z3_OP_BSMOD:
+            case Z3_OP_BSMUL_NO_OVFL:
+            case Z3_OP_BSMUL_NO_UDFL:
+            case Z3_OP_BSDIV_I:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static void set_signedness(Signedness& current, bool is_signed, bool is_unsigned) {
+        assert(!(is_signed && is_unsigned) && "Expression cannot be both signed and unsigned");
+
+        if (is_signed) {
+            if (current == Signedness::UNKNOWN) {
+                current = Signedness::SIGNED;
+            }
+            else if (current == Signedness::UNSIGNED) {
+                current = Signedness::CONFLICT;
+            }
+        }
+        else if (is_unsigned) {
+            if (current == Signedness::UNKNOWN) {
+                current = Signedness::UNSIGNED;
+            }
+            else if (current == Signedness::SIGNED) {
+                current = Signedness::CONFLICT;
+            }
+        }
+        else {
+            current = Signedness::UNKNOWN;
+        }
+    }
+
+    static bool is_unsigned_bv_op(Z3_decl_kind k) {
+        switch (k) {
+            case Z3_OP_ULEQ:
+            case Z3_OP_UGEQ:
+            case Z3_OP_ULT:
+            case Z3_OP_UGT:
+            case Z3_OP_BUDIV:
+            case Z3_OP_BUREM:
+            case Z3_OP_BUMUL_NO_OVFL:
+            case Z3_OP_BUDIV_I:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static bool is_bit_manipulating_bv_op(Z3_decl_kind k) {
+        switch (k) {
+            case Z3_OP_CONCAT:
+            case Z3_OP_EXTRACT:
+            case Z3_OP_REPEAT:
+            case Z3_OP_BAND:
+            case Z3_OP_BOR:
+            case Z3_OP_BNOT:
+            case Z3_OP_BXOR:
+            case Z3_OP_BNAND:
+            case Z3_OP_BNOR:
+            case Z3_OP_BXNOR:
+            case Z3_OP_SIGN_EXT:
+            case Z3_OP_ZERO_EXT:
+            case Z3_OP_BSHL:
+            case Z3_OP_BLSHR:
+            case Z3_OP_BASHR:
+            case Z3_OP_ROTATE_LEFT:
+            case Z3_OP_ROTATE_RIGHT:
+            case Z3_OP_EXT_ROTATE_LEFT:
+            case Z3_OP_EXT_ROTATE_RIGHT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static bool is_sign_neutral_bv_op(Z3_decl_kind k) {
+        return (Z3_OP_BNUM <= k && k <= Z3_OP_BMUL) || (Z3_OP_TRUE <= k && k <= Z3_OP_OEQ);
+    }
+
+    static void analyze_expr(z3::expr const& e, bool is_uninterpreted_predicate_arg, ClauseAnalysisResult& result) {
+        if (e.is_quantifier()) {
+            // In case of horn clauses, this shouldn't be reached
+            // This should be unrecahable as quantifiers should not be present
+            // in the CHC body.
+            UNREACHABLE();
+        }
+        else if (e.is_var()) {
+            result.all_vars.insert(e);
+            if (is_uninterpreted_predicate_arg) {
+                result.bound_vars.insert(e);
+            }
+        }
+        else {
+            // is_app
+            if (e.is_const())
+                return;
+
+            // Analyze signedness and bit-manipulating ops
+            Z3_decl_kind k = e.decl().decl_kind();
+            bool is_sign_neutral = is_sign_neutral_bv_op(k);
+            bool is_signed = is_signed_bv_op(k);
+            bool is_unsigned = is_unsigned_bv_op(k);
+            bool is_bit_manipulating = is_bit_manipulating_bv_op(k);
+            bool is_sign_known = is_signed || is_unsigned;
+            assert(is_sign_known || is_sign_neutral || is_bit_manipulating && "Dealing with an unknown application");
+            if (is_bit_manipulating) {
+                result.has_bit_manipulating_apps = true;
+            }
+
+            set_signedness(result.is_signed, is_signed, is_unsigned);
+
+            for (unsigned i = 0; i < e.num_args(); ++i) {
+                analyze_expr(e.arg(i), is_uninterpreted_predicate_arg, result);
+            }
+        }
+    }
+
+    static void analyze_uninterpreted_predicate(z3::expr const& e, ClauseAnalysisResult& result) {
+        for (unsigned i = 0; i < e.num_args(); ++i) {
+            analyze_expr(e.arg(i), /*is_uninterpreted_predicate_arg*/ true, result);
+        }
+    }
+
+    static void analyze_rule(z3::expr const& body, z3::expr const& head, ClauseAnalysisResult& result) {
+        int conjunct_count = get_num_conjuncts(body);
+        for (int i = 0; i < conjunct_count; ++i) {
+            z3::expr conjunct = (conjunct_count == 1) ? body : body.arg(i);
+            // Check if the conjunct is a predicate application
+            if (is_uninterpreted_predicate(conjunct)) {
+                analyze_uninterpreted_predicate(conjunct, result);
+            }
+            else {
+                analyze_expr(conjunct, /*is_uninterpreted_predicate_arg*/ false, result);
+            }
+        }
+    }
+
+    // Checks if all vars have the same bv_size, and sets result.bv_size accordingly.
+    // If not, result.bv_size is set to UNDETERM_BV_SIZE.
+    static void analyze_vars(z3::expr_vector const& vars, ClauseAnalysisResult& result) {
+        unsigned common_bv_size = UNDETERM_BV_SIZE;
+        bool first = true;
+        for (unsigned i = 0; i < vars.size(); ++i) {
+            z3::sort var_sort = vars[i].get_sort();
+            assert(var_sort.is_bv() && "Variable is expected to be of bv sort");
+            unsigned var_bv_size = var_sort.bv_size();
+            assert(var_bv_size > 0 && "Bit-vector size must be greater than 0");
+            if (first) {
+                common_bv_size = var_bv_size;
+                first = false;
+                continue;
+            }
+            if (var_bv_size != common_bv_size) {
+                common_bv_size = UNDETERM_BV_SIZE;
+                break;
+            }
+        }
+        result.bv_size = common_bv_size;
+    }
+
+    z3::expr_vector get_clause_vars(z3::expr const& clause) {
+        z3::context& c = clause.ctx();
+        z3::expr_vector vars(c);
+        for (int j = 0; j < Z3_get_quantifier_num_bound(c, clause); j++) {
+            z3::symbol sym = z3::symbol(c, Z3_get_quantifier_bound_name(c, clause, j));
+            z3::expr var = c.constant(sym, z3::sort(c, Z3_get_quantifier_bound_sort(c, clause, j)));
+            vars.push_back(var);
+        }
+        return vars;
+    }
+
+    ClauseAnalysisResult analyze_clause(z3::context& ctx, z3::expr const& clause) {
+        assert(clause.is_quantifier() && "The clause must be a quantifier");
+        ClauseAnalysisResult result(ctx);
+
+        z3::expr_vector vars = get_clause_vars(clause);
+        analyze_vars(vars, result);
+
+        // TODO: Implement query analysis
+        if (clause.is_exists())
+            NOT_IMPLEMENTED();
+        else if (clause.is_forall()) {
+            assert(clause.body().is_implies() && "The clause body must be an implication");
+            z3::expr body = clause.body().arg(0);
+            z3::expr head = clause.body().arg(1);
+
+            // TODO: Implement query analysis
+            if (head.is_false())
+                NOT_IMPLEMENTED();
+
+            analyze_rule(body, head, result);
+        }
+        else {
+            // Clause should be a forall or exists clause
+            UNREACHABLE();
+        }
+
+        return result;
+    }
+
+    // ====================================================================
+    // ClauseAnalysisResult methods
+    // ====================================================================
+
+    std::ostream& operator<<(std::ostream& os, const ClauseAnalysisResult& result) {
+        os << "Clause Analysis Result:" << std::endl;
+        os << "  Signedness: ";
+        switch (result.is_signed) {
+            case Signedness::UNKNOWN:
+                os << "UNKNOWN";
+                break;
+            case Signedness::SIGNED:
+                os << "SIGNED";
+                break;
+            case Signedness::UNSIGNED:
+                os << "UNSIGNED";
+                break;
+            case Signedness::CONFLICT:
+                os << "CONFLICT";
+                break;
+        }
+        os << std::endl;
+
+        os << "  BV Size: ";
+        if (result.is_bv_size_determined()) {
+            os << result.bv_size;
+        } else {
+            os << "UNDETERMINED";
+        }
+        os << std::endl;
+
+        os << "  Has Bit-Manipulating Apps: " << (result.has_bit_manipulating_apps ? "Yes" : "No") << std::endl;
+
+        os << "  Bound Variables: ";
+        int num_bound_vars = result.bound_vars.size();
+        for (int i = 0; i < num_bound_vars; ++i) {
+            auto var = *std::next(result.bound_vars.begin(), i);
+            os << var;
+            if (i != num_bound_vars - 1) {
+                os << ", ";
+            }
+        }
+        os << std::endl;
+
+        os << "  All Variables: ";
+        int num_all_vars = result.all_vars.size();
+        for (int i = 0; i < num_all_vars; ++i) {
+            auto var = *std::next(result.all_vars.begin(), i);
+            os << var;
+            if (i != num_all_vars - 1) {
+                os << ", ";
+            }
+        }
+        os << std::endl;
+        return os;
+    }
+}

--- a/src/mth_utils.h
+++ b/src/mth_utils.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <z3++.h>
+#include <map>
+#include <optional>
+#include <set>
+#include "utils.h"
+
+namespace multi_theory_horn {
+    struct CHC {
+        z3::expr_vector const vars;
+        z3::expr body_preds;
+        z3::expr body_formula;
+        z3::expr head;
+
+        CHC(z3::expr_vector const& v, z3::expr bp, z3::expr bf, z3::expr h)
+            : vars(v), body_preds(bp), body_formula(bf), head(h) {}
+
+        z3::expr get_rule_expr() const {
+            assert(!head.is_true() || !head.is_false() && 
+                        "Head of normal CHC rule cannot be a boolean expression");
+            return z3::forall(vars, z3::implies(body_preds && body_formula, head));
+        }
+
+        z3::expr get_query_expr() const {
+            assert(head.is_false() && 
+                        "Head of query CHC must be false");
+            return z3::exists(vars, body_preds && body_formula);
+        }
+
+        z3::expr get_body_expr() const {
+            return body_preds && body_formula;
+        }
+    };
+
+    enum class Theory { IAUF, BV };
+
+    enum class Signedness { UNKNOWN, SIGNED, UNSIGNED, CONFLICT };
+    static constexpr unsigned UNDETERM_BV_SIZE = std::numeric_limits<unsigned>::max();
+    struct ClauseAnalysisResult {
+        Signedness is_signed;
+        unsigned bv_size; // UNDETERM_BV_SIZE if not uniquely determined.
+        bool has_bit_manipulating_apps;
+        // Variables that do not occur in any predicate application
+        // in the body of the clause.
+        std::set<z3::expr, compare_expr> bound_vars;
+        std::set<z3::expr, compare_expr> all_vars;
+
+        ClauseAnalysisResult(z3::context& ctx)
+            : bound_vars(), all_vars(), is_signed(Signedness::UNKNOWN), bv_size(UNDETERM_BV_SIZE),
+              has_bit_manipulating_apps(false) {}
+
+        bool is_bv_size_determined() const {
+            return bv_size != UNDETERM_BV_SIZE;
+        }
+
+        bool is_signedness_determined() const {
+            return is_signed != Signedness::UNKNOWN && is_signed != Signedness::CONFLICT;
+        }
+
+        // Declare operator<< for easy printing
+        friend std::ostream& operator<<(std::ostream& os, const ClauseAnalysisResult& result);
+    };
+
+    /// @brief Return an expr_vector containing all the variables of the CHC clause.
+    /// A CHC clause is of the form:
+    /// forall x1 ... xn. (body => head)
+    /// @param clause The CHC clause to extract variables from.
+    /// @return An expr_vector containing all the variables of the CHC clause.
+    z3::expr_vector get_clause_vars(z3::expr const& clause);
+
+    /// @brief Analyze the given CHC clause and return the result. We try to infer:
+    /// - The signedness of the bit-vector operations in the clause.
+    /// - The bit-vector size used in the clause.
+    /// - Whether the clause contains bit-manipulating operations.
+    /// - The free variables in the body of the clause.
+    /// @param ctx The Z3 context.
+    /// @param clause The CHC clause to analyze.
+    /// @return The result of the clause analysis in a ClauseAnalysisResult struct.
+    ClauseAnalysisResult analyze_clause(z3::context& ctx, z3::expr const& clause);
+
+} // namespace multi_theory_horn

--- a/src/mth_utils.h
+++ b/src/mth_utils.h
@@ -7,6 +7,145 @@
 #include "utils.h"
 
 namespace multi_theory_horn {
+    // Centralized output sinks (default to std::cout/std::cerr)
+    inline std::ostream* g_out = &std::cout;
+    inline std::ostream* g_err = &std::cerr;
+
+    inline void set_output_stream(std::ostream& os) { g_out = &os; }
+    inline void set_error_stream(std::ostream& os) { g_err = &os; }
+
+    inline std::ostream& OUT() { return *g_out; }
+    inline std::ostream& ERR() { return *g_err; }
+
+    #define NOT_IMPLEMENTED() \
+        do { \
+            OUT() << "Not implemented: " << __FILE__ << ":" << __LINE__ << std::endl; \
+            assert(false && "Not implemented"); \
+            exit(1); \
+        } while (0)
+
+    #define UNREACHABLE() \
+        do { \
+            OUT() << "Unreachable code reached: " << __FILE__ << ":" << __LINE__ << std::endl; \
+            assert(false && "Unreachable code reached"); \
+            exit(1); \
+        } while (0)
+
+    // Add assert(false) with message macro
+    #define ASSERT_FALSE(msg) \
+        do { \
+            OUT() << "Assertion failed: " << msg << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+            assert(false && msg); \
+            exit(1); \
+        } while (0)
+
+    // DEBUG related stuff
+    inline bool mtfp_debug = false;
+    inline void set_mtfp_debug(bool is_debug) {
+        mtfp_debug = is_debug;
+    }
+    #define DEBUG_MSG(cmd) \
+        do { \
+            if (mtfp_debug) { \
+                OUT() << "-------------------------------------------------------" << std::endl; \
+                cmd; \
+            } \
+        } while (0)
+
+    struct AstHash {
+        std::size_t operator()(Z3_ast a) const noexcept {
+            return reinterpret_cast<std::size_t>(a);
+        }
+    };
+    struct AstEq {
+        bool operator()(Z3_ast a, Z3_ast b) const noexcept {
+            return a == b;
+        }
+    };
+
+    struct compare_func_decl {
+		bool operator() (const z3::func_decl& lhs, const z3::func_decl& rhs) const {
+			return lhs.id() < rhs.id();
+		}
+	};
+
+    struct compare_expr {
+        bool operator() (const z3::expr& lhs, const z3::expr& rhs) const {
+            return lhs.hash() < rhs.hash();
+        }
+    };
+
+    using VarMap = std::map<z3::expr, z3::expr, compare_expr>;
+    inline std::string dump(const VarMap& var_map) {
+        std::string result = "{\n";
+        for (const auto& pair : var_map) {
+            result += "  " + pair.first.to_string() + " -> " + pair.second.to_string() + "\n";
+        }
+        result += "}";
+        return result;
+    }
+    using VarSet = std::set<z3::expr, compare_expr>;
+    using VarIndexMap = std::map<z3::expr, int, compare_expr>;
+    using VarLemmaMap = std::map<z3::expr, z3::expr, compare_expr>;
+    class PredicateMap {
+        using Map = std::map<
+            z3::func_decl,
+            z3::expr,
+            compare_func_decl
+        >;
+
+        std::map<z3::func_decl, z3::expr_vector, compare_func_decl> srcVarMap;
+        std::map<z3::func_decl, z3::expr_vector, compare_func_decl> dstVarMap;
+        Map Theta;
+
+    public:
+        void insert(z3::expr& p1, z3::expr& p2) {
+            // The interface constraint is p1 -> p2
+            // The key is the destination predicate p2 because of the
+            // assumption that each predicate has at most one predecessor
+            assert(Theta.find(p2.decl()) == Theta.end() && 
+                "PredicateMap: first predicate is already mapped");
+            Theta.emplace(p2.decl(), p1);
+            srcVarMap.emplace(p1.decl(), p1.args());
+            dstVarMap.emplace(p2.decl(), p2.args());
+        }
+
+        std::optional<z3::expr> find_pred(const z3::func_decl& dst) const {
+            // Given a destination predicate, return the source predicate
+            auto it = Theta.find(dst);
+            if (it != Theta.end()) {
+                return it->second; // Return the source predicate
+            }
+            return std::nullopt; // Not found
+        }
+
+        std::optional<z3::func_decl> find_next(const z3::expr& src) const {
+            // Look if there's a key that its value is the src argument
+            //! We assume that there's at most one such key
+            for (const auto& pair : Theta)
+                if (pair.second.decl().id() == src.decl().id())
+                    return pair.first;
+
+            return std::nullopt;
+        }
+
+        z3::expr_vector get_src_vars(const z3::func_decl& src) const {
+            // Get the source variables for a given destination predicate
+            auto it = srcVarMap.find(src);
+            assert(it != srcVarMap.end() && 
+                "PredicateMap: source variables not found for the given predicate");
+            return it->second; // Return the source variables
+        }
+
+        z3::expr_vector get_dst_vars(const z3::func_decl& dst) const {
+            // Get the destination variables for a given source predicate
+            auto it = dstVarMap.find(dst);
+            assert(it != dstVarMap.end() && 
+                "PredicateMap: destination variables not found for the given predicate");
+            return it->second; // Return the destination variables
+        }
+    };
+
     struct CHC {
         z3::expr_vector const vars;
         z3::expr body_preds;

--- a/src/multi_theory_fixedpoint.cpp
+++ b/src/multi_theory_fixedpoint.cpp
@@ -95,12 +95,12 @@ namespace multi_theory_horn {
         z3::expr head = underlying_clause.arg(1);
 
         // TODO: Maybe inline the following logic in the translator itself.
-        int num_conjuncts = get_num_conjuncts(body);
+        int num_conjuncts = utils::get_num_conjuncts(body);
         z3::expr_vector new_conjunct(ctx);
         for (int i = 0; i < num_conjuncts; ++i) {
             z3::expr conjunct = (num_conjuncts == 1) ? body : body.arg(i);
             z3::expr translated_conjunct(ctx);
-            if (is_uninterpreted_predicate(conjunct)) {
+            if (utils::is_uninterpreted_predicate(conjunct)) {
                 z3::func_decl p_new = bv_predicate_to_int(conjunct.decl(), clause_analysis.bv_size);
                 z3::expr translated_arg(ctx);
                 z3::expr_vector new_args(ctx);
@@ -132,7 +132,7 @@ namespace multi_theory_horn {
 
         z3::expr new_body = z3::mk_and(new_conjunct);
         z3::expr new_head(ctx);
-        assert(is_uninterpreted_predicate(head) && "Head must be an uninterpreted predicate");
+        assert(utils::is_uninterpreted_predicate(head) && "Head must be an uninterpreted predicate");
         z3::func_decl p_head_new = bv_predicate_to_int(head.decl(), clause_analysis.bv_size);
         z3::expr_vector new_head_args(ctx);
         for (unsigned j = 0; j < head.num_args(); ++j) {

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -6,40 +6,12 @@
 #pragma once
 #include <z3++.h>
 #include <stack>
+#include "mth_utils.h"
 #include "utils.h"
 #include "Bv2IntTranslator.h"
 #include "Int2BvTranslator.h"
 
 namespace multi_theory_horn {
-    enum class Theory { IAUF, BV };
-
-    struct CHC {
-        z3::expr_vector const vars;
-        z3::expr body_preds;
-        z3::expr body_formula;
-        z3::expr head;
-
-        CHC(z3::expr_vector const& v, z3::expr bp, z3::expr bf, z3::expr h)
-            : vars(v), body_preds(bp), body_formula(bf), head(h) {}
-
-        z3::expr get_rule_expr() const {
-            assert(!head.is_true() || !head.is_false() && 
-                        "Head of normal CHC rule cannot be a boolean expression");
-            return z3::forall(vars, z3::implies(body_preds && body_formula, head));
-        }
-
-        z3::expr get_query_expr() const {
-            assert(head.is_false() && 
-                        "Head of query CHC must be false");
-            return z3::exists(vars, body_preds && body_formula);
-        }
-
-        z3::expr get_body_expr() const {
-            return body_preds && body_formula;
-        }
-    };
-
-
     class MT_fixedpoint {
     private:
         z3::context& m_ctx;

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -6,8 +6,8 @@
 #pragma once
 #include <z3++.h>
 #include <stack>
-#include "mth_utils.h"
 #include "utils.h"
+#include "mth_utils.h"
 #include "Bv2IntTranslator.h"
 #include "Int2BvTranslator.h"
 
@@ -15,6 +15,8 @@ namespace multi_theory_horn {
     class MT_fixedpoint {
     private:
         z3::context& m_ctx;
+
+        MTHFixedpointSet m_mth_fp_set;
         z3::fixedpoint m_fp_int;
         z3::fixedpoint m_fp_bv;
         unsigned m_bv_size;
@@ -55,7 +57,7 @@ namespace multi_theory_horn {
         /// @brief A function that return a conjunction of bit-vector bound expressions
         /// of the form `0 <= var < 2^bv_size` for each variable in `vars`.
         /// @param vars The vector of bit-vector variables for which to create the bound expressions.
-        z3::expr get_bv_expr_bound(z3::expr_vector const& vars);
+        z3::expr get_bv_expr_bound(z3::expr_vector const& vars) const;
 
         /// @brief Adds behind the scenes a fact corresponding to the predicate given by p_expr
         /// which is the destination of an interface constraint.
@@ -71,8 +73,11 @@ namespace multi_theory_horn {
         // Construction / destruction
         //--------------------------------------------------------------------------
         explicit MT_fixedpoint(z3::context& ctx, bool is_signed, unsigned bv_size, bool int2bv_preprocess = true, bool simplify = true);
-        explicit MT_fixedpoint(z3::context& ctx);
+        explicit MT_fixedpoint(z3::context& ctx, bool int2bv_preprocess = true, bool simplify = true);
 
+        /// @brief Initializes the multi-theory fixedpoint engine from
+        /// an existing BV fixedpoint engine.
+        /// @param fp The existing BV fixedpoint engine.
         void from_solver(z3::fixedpoint& fp);
 
         //--------------------------------------------------------------------------

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -17,6 +17,9 @@ namespace multi_theory_horn {
         z3::context& m_ctx;
 
         MTHFixedpointSet m_mth_fp_set;
+        z3::expr_vector m_original_clauses;
+        std::map<z3::expr, ClauseAnalysisResult, compare_expr> m_clause_analysis_map;
+
         z3::fixedpoint m_fp_int;
         z3::fixedpoint m_fp_bv;
         unsigned m_bv_size;
@@ -67,6 +70,16 @@ namespace multi_theory_horn {
         /// @param theory The theory of the source predicate of the interface constraint.
         void add_predicate_fact(z3::func_decl const& key, z3::expr const& p_expr, Theory theory);
 
+        /// @brief Checks the signedness consistency of the clause analysis result.
+        /// @param clause_analysis The clause analysis result to check.
+        void check_signedness_consistency(ClauseAnalysisResult const& clause_analysis);
+
+        /// @brief Populates the fixedpoint engines before executing queries.
+        /// This includes going over the original clauses, their analysis results,
+        /// and adding them to the appropriate fixedpoint engine after translation
+        /// if necessary.
+        void populate_MTH_fixedpoint_engines();
+
     public:
 
         //--------------------------------------------------------------------------
@@ -98,11 +111,10 @@ namespace multi_theory_horn {
         /// \param theory The theory indicating the engine to which the query belongs.
         z3::check_result query(z3::expr_vector& vars, z3::expr& q_pred, z3::expr& q_phi, Theory theory);
 
-        //--------------------------------------------------------------------------
-        // Updated query declaration
-        //--------------------------------------------------------------------------
-        // The theory of the query is determined internally, so no explicit theory parameter is required. 
-        z3::check_result query(z3::expr_vector& vars, z3::expr& q_pred, z3::expr& q_phi);
+        /// \brief The query method for the multi-theory fixedpoint engine.
+        /// \param query The query expression.
+        /// \return The result of the query.
+        z3::check_result query(z3::expr& query);
 
         //--------------------------------------------------------------------------
         // Forwarding of fixepoint most common calles

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,23 @@
+#include "utils.h"
+
+namespace multi_theory_horn {
+
+    /// @brief An auxiliary function for recursively getting conjuncts.
+    /// @param e The expression to analyze.
+    /// @param conjuncts The vector to store the resulting conjuncts.
+    static void get_conjuncts_impl(const z3::expr& e, z3::expr_vector& conjuncts) {
+        if (e.is_and()) {
+            for (unsigned i = 0; i < e.num_args(); ++i) {
+                get_conjuncts_impl(e.arg(i), conjuncts);
+            }
+        } else {
+            conjuncts.push_back(e);
+        }
+    }
+
+    z3::expr_vector get_conjuncts(const z3::expr& e) {
+        z3::expr_vector conjuncts(e.ctx());
+        get_conjuncts_impl(e, conjuncts);
+        return conjuncts;
+    }
+} // namespace multi_theory_horn

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,6 @@
 #include "utils.h"
 
-namespace multi_theory_horn {
+namespace utils {
 
     /// @brief An auxiliary function for recursively getting conjuncts.
     /// @param e The expression to analyze.
@@ -15,9 +15,44 @@ namespace multi_theory_horn {
         }
     }
 
+    //==============================================================================
+    //                              PUBLIC METHODS
+    //==============================================================================
     z3::expr_vector get_conjuncts(const z3::expr& e) {
         z3::expr_vector conjuncts(e.ctx());
         get_conjuncts_impl(e, conjuncts);
         return conjuncts;
     }
-} // namespace multi_theory_horn
+
+    int64_t sign_extend(uint64_t raw, unsigned width) {
+        // keep only the low 'width' bits
+        int64_t mask = (1 << width) - 1;
+        int64_t u    = raw & mask;
+        // if top bit set, subtract 2^width
+        if (u & (1 << (width-1)))
+            u -= (1 << width);
+        return u;
+    }
+
+    bool is_uninterpreted_predicate(const z3::expr& e) {
+        return e.decl().decl_kind() == Z3_OP_UNINTERPRETED;
+    }
+
+    int64_t get_signed_bv_lower_bound(unsigned bv_size) {
+        return -(int64_t(1) << (bv_size - 1));
+    }
+
+    int64_t get_signed_bv_upper_bound(unsigned bv_size) {
+        return (int64_t(1) << (bv_size - 1)) - 1;
+    }
+
+    uint64_t get_unsigned_bv_upper_bound(unsigned bv_size) {
+        if (bv_size >= 64)
+            return std::numeric_limits<uint64_t>::max();
+        return (uint64_t(1) << bv_size) - 1;
+    }
+
+    uint64_t get_unsigned_bv_lower_bound(unsigned bv_size) {
+        return 0;
+    }
+} // namespace utils

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,12 +20,17 @@ namespace multi_theory_horn {
         }
     };
 
-
     struct compare_func_decl {
 		bool operator() (const z3::func_decl& lhs, const z3::func_decl& rhs) const {
 			return lhs.id() < rhs.id();
 		}
 	};
+
+    struct compare_expr {
+        bool operator() (const z3::expr& lhs, const z3::expr& rhs) const {
+            return lhs.hash() < rhs.hash();
+        }
+    };
 
     using VarMap = std::map<z3::func_decl, z3::expr, compare_func_decl>;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,101 +8,7 @@
 #include <z3++.h>
 #include <limits>
 
-namespace multi_theory_horn {
-
-    struct AstHash {
-        std::size_t operator()(Z3_ast a) const noexcept {
-            return reinterpret_cast<std::size_t>(a);
-        }
-    };
-    struct AstEq {
-        bool operator()(Z3_ast a, Z3_ast b) const noexcept {
-            return a == b;
-        }
-    };
-
-    struct compare_func_decl {
-		bool operator() (const z3::func_decl& lhs, const z3::func_decl& rhs) const {
-			return lhs.id() < rhs.id();
-		}
-	};
-
-    struct compare_expr {
-        bool operator() (const z3::expr& lhs, const z3::expr& rhs) const {
-            return lhs.hash() < rhs.hash();
-        }
-    };
-
-    using VarMap = std::map<z3::expr, z3::expr, compare_expr>;
-    inline std::string dump(const VarMap& var_map) {
-        std::string result = "{\n";
-        for (const auto& pair : var_map) {
-            result += "  " + pair.first.to_string() + " -> " + pair.second.to_string() + "\n";
-        }
-        result += "}";
-        return result;
-    }
-    using VarSet = std::set<z3::expr, compare_expr>;
-    using VarIndexMap = std::map<z3::expr, int, compare_expr>;
-    using VarLemmaMap = std::map<z3::expr, z3::expr, compare_expr>;
-    class PredicateMap {
-        using Map = std::map<
-            z3::func_decl,
-            z3::expr,
-            compare_func_decl
-        >;
-
-        std::map<z3::func_decl, z3::expr_vector, compare_func_decl> srcVarMap;
-        std::map<z3::func_decl, z3::expr_vector, compare_func_decl> dstVarMap;
-        Map Theta;
-
-    public:
-        void insert(z3::expr& p1, z3::expr& p2) {
-            // The interface constraint is p1 -> p2
-            // The key is the destination predicate p2 because of the
-            // assumption that each predicate has at most one predecessor
-            assert(Theta.find(p2.decl()) == Theta.end() && 
-                "PredicateMap: first predicate is already mapped");
-            Theta.emplace(p2.decl(), p1);
-            srcVarMap.emplace(p1.decl(), p1.args());
-            dstVarMap.emplace(p2.decl(), p2.args());
-        }
-
-        std::optional<z3::expr> find_pred(const z3::func_decl& dst) const {
-            // Given a destination predicate, return the source predicate
-            auto it = Theta.find(dst);
-            if (it != Theta.end()) {
-                return it->second; // Return the source predicate
-            }
-            return std::nullopt; // Not found
-        }
-
-        std::optional<z3::func_decl> find_next(const z3::expr& src) const {
-            // Look if there's a key that its value is the src argument
-            //! We assume that there's at most one such key
-            for (const auto& pair : Theta)
-                if (pair.second.decl().id() == src.decl().id())
-                    return pair.first;
-
-            return std::nullopt;
-        }
-
-        z3::expr_vector get_src_vars(const z3::func_decl& src) const {
-            // Get the source variables for a given destination predicate
-            auto it = srcVarMap.find(src);
-            assert(it != srcVarMap.end() && 
-                "PredicateMap: source variables not found for the given predicate");
-            return it->second; // Return the source variables
-        }
-
-        z3::expr_vector get_dst_vars(const z3::func_decl& dst) const {
-            // Get the destination variables for a given source predicate
-            auto it = dstVarMap.find(dst);
-            assert(it != dstVarMap.end() && 
-                "PredicateMap: destination variables not found for the given predicate");
-            return it->second; // Return the destination variables
-        }
-    };
+namespace utils {
 
     template<typename S, typename T>
     bool any_of(S const& set, T const& p) {
@@ -132,77 +38,34 @@ namespace multi_theory_horn {
         return 1;
     }
 
-    inline bool is_uninterpreted_predicate(const z3::expr& e) {
-        return e.decl().decl_kind() == Z3_OP_UNINTERPRETED;
-    }
+    /// @brief Checks if the given expression is an uninterpreted predicate.
+    /// @param e The expression to check.
+    /// @return True if the expression is an uninterpreted predicate, false otherwise.
+    bool is_uninterpreted_predicate(const z3::expr& e);
 
-    inline int64_t sign_extend(uint64_t raw, unsigned width) {
-        // keep only the low 'width' bits
-        int64_t mask = (1 << width) - 1;
-        int64_t u    = raw & mask;
-        // if top bit set, subtract 2^width
-        if (u & (1 << (width-1)))
-            u -= (1 << width);
-        return u;
-    }
+    /// @brief Sign-extends the given raw bit-vector value of the specified width.
+    /// @param raw The raw bit-vector value.
+    /// @param width The width of the bit-vector.
+    /// @return The sign-extended value.
+    int64_t sign_extend(uint64_t raw, unsigned width);
 
-    inline int64_t get_signed_bv_lower_bound(unsigned bv_size) {
-        return -(int64_t(1) << (bv_size - 1));
-    }
-    inline int64_t get_signed_bv_upper_bound(unsigned bv_size) {
-        return (int64_t(1) << (bv_size - 1)) - 1;
-    }
-    inline uint64_t get_unsigned_bv_upper_bound(unsigned bv_size) {
-        if (bv_size >= 64)
-            return std::numeric_limits<uint64_t>::max();
-        return (uint64_t(1) << bv_size) - 1;
-    }
-    inline uint64_t get_unsigned_bv_lower_bound(unsigned bv_size) {
-        return 0;
-    }
+    /// @brief Gets the lower bound of a signed bit-vector of the given size.
+    /// @param bv_size The size of the bit-vector.
+    /// @return The lower bound.
+    int64_t get_signed_bv_lower_bound(unsigned bv_size);
 
-    // Centralized output sinks (default to std::cout/std::cerr)
-    inline std::ostream* g_out = &std::cout;
-    inline std::ostream* g_err = &std::cerr;
+    /// @brief Gets the upper bound of a signed bit-vector of the given size.
+    /// @param bv_size The size of the bit-vector.
+    /// @return The upper bound.
+    int64_t get_signed_bv_upper_bound(unsigned bv_size);
 
-    inline void set_output_stream(std::ostream& os) { g_out = &os; }
-    inline void set_error_stream(std::ostream& os) { g_err = &os; }
+    /// @brief Gets the upper bound of an unsigned bit-vector of the given size.
+    /// @param bv_size The size of the bit-vector.
+    /// @return The upper bound.
+    uint64_t get_unsigned_bv_upper_bound(unsigned bv_size);
 
-    inline std::ostream& OUT() { return *g_out; }
-    inline std::ostream& ERR() { return *g_err; }
-
-    #define NOT_IMPLEMENTED() \
-        do { \
-            OUT() << "Not implemented: " << __FILE__ << ":" << __LINE__ << std::endl; \
-            assert(false && "Not implemented"); \
-            exit(1); \
-        } while (0)
-
-    #define UNREACHABLE() \
-        do { \
-            OUT() << "Unreachable code reached: " << __FILE__ << ":" << __LINE__ << std::endl; \
-            assert(false && "Unreachable code reached"); \
-            exit(1); \
-        } while (0)
-
-    // Add assert(false) with message macro
-    #define ASSERT_FALSE(msg) \
-        do { \
-            OUT() << "Assertion failed: " << msg << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
-            assert(false && msg); \
-            exit(1); \
-        } while (0)
-
-    // DEBUG related stuff
-    inline bool mtfp_debug = false;
-    inline void set_mtfp_debug(bool is_debug) {
-        mtfp_debug = is_debug;
-    }
-    #define DEBUG_MSG(cmd) \
-        do { \
-            if (mtfp_debug) { \
-                OUT() << "-------------------------------------------------------" << std::endl; \
-                cmd; \
-            } \
-        } while (0)
-}
+    /// @brief Gets the lower bound of an unsigned bit-vector of the given size.
+    /// @param bv_size The size of the bit-vector.
+    /// @return The lower bound.
+    uint64_t get_unsigned_bv_lower_bound(unsigned bv_size);
+} // namespace utils


### PR DESCRIPTION
Added an automatic method that extracts from a clause the following:
1. If it contains only signed, only unsigned or conflicting signdness.
2. bv_size which is determined by the unique size of all variables.
3. If the clause has bit manipulating bv opcodes.
4. All variables.
5. Bound variables; i.e. not used by any uninterpreted variables in the body.