### PR TITLE
[AMTH] Implement interface constraints generation

### DIFF
--- a/src/multi_theory_fixedpoint.cpp
+++ b/src/multi_theory_fixedpoint.cpp
@@ -243,29 +243,6 @@ namespace multi_theory_horn {
         return kAdded_fact_name + std::to_string(added_fact_counter++);
     }
 
-    void MT_fixedpoint::add_variable_map(z3::expr_vector bv_vars, z3::expr_vector int_vars) {
-        assert(bv_vars.size() == int_vars.size() && "The size of bv_vars and int_vars must be the same");
-        
-        // This is used only to create an assertion
-        [[maybe_unused]] auto arg_is_const = [](const z3::expr& e) {
-            // Checks if e is an argument (an app of arity 0)
-            return e.is_const() && !e.is_numeral();
-        };
-        
-        for (int i = 0; i < bv_vars.size(); ++i) {
-            assert(arg_is_const(bv_vars[i]) && "bv_vars must contain a BV variable");
-            assert(arg_is_const(int_vars[i]) && "int_vars must contain an int variable");
-
-            DEBUG_MSG(OUT() << "Adding variable map: " 
-                << bv_vars[i] << " <-> " << int_vars[i] << std::endl);
-
-            // Insert the int variable into the bv2int_var_map
-            m_bv2int_var_map.emplace(bv_vars[i], int_vars[i]);
-            // Insert the bv variable into the int2bv_var_map
-            m_int2bv_var_map.emplace(int_vars[i], bv_vars[i]);
-        }
-    }
-
     void MT_fixedpoint::check_signedness_consistency(ClauseAnalysisResult const& clause_analysis) {
         if (clause_analysis.has_conflicting_signedness())
             ASSERT_FALSE("Clause has conflicting signedness information");
@@ -495,13 +472,9 @@ namespace multi_theory_horn {
                                                  z3::expr p2_expr, Theory theory_2) {
         if (theory_1 == Theory::IAUF && theory_2 == Theory::BV) {
             std::ignore = m_int2bv_map.insert(p1_expr, p2_expr);
-            // Map the variables to allow translation between the two theories
-            add_variable_map(p2_expr.args(), p1_expr.args());
         }
         else if (theory_1 == Theory::BV && theory_2 == Theory::IAUF) {
             std::ignore = m_bv2int_map.insert(p1_expr, p2_expr);
-            // Map the variables to allow translation between the two theories
-            add_variable_map(p1_expr.args(), p2_expr.args());
         }
         else
             ASSERT_FALSE("theory_1 and theory_2 must be different theories");

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -37,9 +37,6 @@ namespace multi_theory_horn {
         PredicateMap m_int2bv_map;
         PredicateMap m_bv2int_map;
 
-        // TODO: Check if it's possible to delete these maps
-        VarMap m_int2bv_var_map;
-        VarMap m_bv2int_var_map;
         std::unordered_map<Z3_ast, CHCFactConfig, AstHash, AstEq> m_p_to_fact_map;
         std::map<z3::func_decl, z3::expr, compare_func_decl> m_p_to_strengthening_expr_map;
 
@@ -47,12 +44,6 @@ namespace multi_theory_horn {
         unsigned added_fact_counter = 0;
 
         std::string get_fresh_added_fact_name();
-
-        /// @brief Adds a bi-directional mapping between sets of variables
-        /// @param bv_vars BV set of variables
-        /// @param int_vars integer set of variables
-        /// @note This method assumes the variables are sorted and of the same size.
-        void add_variable_map(z3::expr_vector bv_vars, z3::expr_vector int_vars);
 
         /// @brief A method that finds the leaf predicate of a refutation.
         /// @param refutation The refutation expression to analyze.


### PR DESCRIPTION
The tries to create interface constraints if either src or dst is of sort BV.
We go over all integer rules:
  1. We try to create INT->BV IC from the rule's head to a body predicate in some BV rule/query.
  2. We try to create BV->INT IC from either one of the rule's body predicates to a head predicate in some BV rule.