### PR TITLE
[AMTH] Don't conjoin lemmas when moving between theories

### DIFF
--- a/src/multi_theory_fixedpoint.cpp
+++ b/src/multi_theory_fixedpoint.cpp
@@ -648,12 +648,7 @@ namespace multi_theory_horn {
                     if (is_bv_solver) {
                         Bv2IntTranslator bv2int_t(m_ctx, is_signed, m_simplify, /* no_overflow */ false, var_map);
                         p_interp_trans = bv2int_t.translate(p_interp);
-                        // Go over all the lemmas and conjoin them with the translated predicate
-                        z3::expr_vector lemmas(m_ctx);
-                        for (const auto& kv : bv2int_t.lemmas()) {
-                            lemmas.push_back(kv.second);
-                        }
-                        p_interp_trans = p_interp_trans && z3::mk_and(lemmas);
+                        p_interp_trans = p_interp_trans;
                     }
                     else {
                         unsigned bv_size = current_solver->get_bv_size();


### PR DESCRIPTION
Reason: In the new implementation, we make sure to add the bounds constraints from as early as adding the rules to the relevant solver.