### PR TITLE
[AMTH] Generalize is_uinterpreted_predicate utility

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,7 +35,8 @@ namespace utils {
     }
 
     bool is_uninterpreted_predicate(const z3::expr& e) {
-        return e.decl().decl_kind() == Z3_OP_UNINTERPRETED;
+        Z3_decl_kind kind = e.decl().decl_kind();
+        return kind == Z3_OP_UNINTERPRETED || kind == Z3_OP_RECURSIVE;
     }
 
     int64_t get_signed_bv_lower_bound(unsigned bv_size) {


### PR DESCRIPTION
For some reason, on LINUX uninterpreted predicates are AST nodes of RECURSIVE.
On MAC they are of type UNINTERPRETED