### PR TITLE
[AMTH] Refactor the old interface to use the automatic approach

### DIFF
--- a/src/mth_utils.cpp
+++ b/src/mth_utils.cpp
@@ -338,7 +338,6 @@ namespace multi_theory_horn {
     MTHSolver& MTHFixedpointSet::getOrInitBVSolver() {
         if (!bv_solver.has_value()) {
             MTHSolver new_solver(ctx, /*is_bv*/ true);
-            new_solver.fp_solver.set(get_default_mth_fp_params(ctx));
             bv_solver.emplace(std::move(new_solver));
         }
         return *bv_solver;
@@ -360,8 +359,6 @@ namespace multi_theory_horn {
             return it->second;
 
         MTHSolver new_solver(ctx, /*is_bv*/ false, bv_size);
-        new_solver.fp_solver.set(get_default_mth_fp_params(ctx));
-
         auto result = iauf_solvers.emplace(
             std::piecewise_construct,
             std::forward_as_tuple(bv_size),

--- a/src/mth_utils.h
+++ b/src/mth_utils.h
@@ -161,9 +161,6 @@ namespace multi_theory_horn {
         }
     };
 
-    // TODO: Delete this when not needed.
-    enum class Theory { IAUF, BV };
-
     struct MTHSolver {
         z3::fixedpoint fp_solver;
         z3::expr query;

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -22,7 +22,12 @@ namespace multi_theory_horn {
         // Whether to preprocess integer translator formulas (default: false)
         bool m_int2bv_preprocess;
 
+        // The set of fixedpoint solvers
         MTHFixedpointSet m_mth_fp_set;
+        // The parameters for all the engines
+        bool m_params_set;
+        z3::params m_params;
+
         z3::expr_vector m_original_clauses;
         std::map<z3::expr, ClauseAnalysisResult, compare_expr> m_clause_analysis_map;
         PredicateMap m_interface_constraint_map;
@@ -90,6 +95,10 @@ namespace multi_theory_horn {
         /// populated fixedpoint engines.
         void generate_interface_constraints();
 
+        /// @brief Sets the parameters for all fixedpoint engines.
+        /// If m_params_set is true, uses m_params. Otherwise, uses default parameters.
+        void set_params_for_all_engines();
+
     public:
 
         //--------------------------------------------------------------------------
@@ -114,6 +123,10 @@ namespace multi_theory_horn {
         /// @brief Register a relation (predicate) in the appropriate fixedpoint engine.
         /// @param p The predicate to register.
         void register_relation(z3::func_decl& p);
+
+        /// @brief Set parameters for both all fixedpoint engines.
+        /// @param p The parameters to set.
+        void set(z3::params const & p);
 
         /// @brief The query method for the multi-theory fixedpoint engine.
         /// @param query The query expression.

--- a/src/multi_theory_fixedpoint.h
+++ b/src/multi_theory_fixedpoint.h
@@ -15,6 +15,12 @@ namespace multi_theory_horn {
     class MT_fixedpoint {
     private:
         z3::context& m_ctx;
+        // Whether to treat bit-vectors as signed or unsigned
+        std::optional<bool> m_is_signed;
+        // Whether to simplify the translations (default: true)
+        bool m_simplify;
+        // Whether to preprocess integer translator formulas (default: false)
+        bool m_int2bv_preprocess;
 
         MTHFixedpointSet m_mth_fp_set;
         z3::expr_vector m_original_clauses;
@@ -29,22 +35,8 @@ namespace multi_theory_horn {
         std::map<z3::func_decl, z3::expr_vector, compare_func_decl> m_interface_dst_vars;
         PredicateToExprMap m_interface_dst_orig_head_to_clause_map;
 
-        z3::fixedpoint m_fp_int;
-        z3::fixedpoint m_fp_bv;
-        unsigned m_bv_size;
-        std::optional<bool> m_is_signed; // Whether to treat bit-vectors as signed or unsigned
-        bool m_simplify; // Whether to simplify the translations
-        bool m_int2bv_preprocess; // Whether to preprocess integer translator formulas
-
-        PredicateMap m_int2bv_map;
-        PredicateMap m_bv2int_map;
-
-        std::unordered_map<Z3_ast, CHCFactConfig, AstHash, AstEq> m_p_to_fact_map;
-        std::map<z3::func_decl, z3::expr, compare_func_decl> m_p_to_strengthening_expr_map;
-
         std::string kAdded_fact_name = "__added_fact__";
         unsigned added_fact_counter = 0;
-
         std::string get_fresh_added_fact_name();
 
         /// @brief A method that finds the leaf predicate of a refutation.
@@ -63,14 +55,6 @@ namespace multi_theory_horn {
         /// @param vars The vector of bit-vector variables for which to create the bound expressions.
         /// @param bv_size The size of the bit-vectors.
         z3::expr get_bv_expr_bounds(z3::expr_vector const& vars, unsigned bv_size) const;
-
-        /// @brief Adds behind the scenes a fact corresponding to the predicate given by p_expr
-        /// which is the destination of an interface constraint.
-        /// @param key The key ast of the source predicate. Its key is used to identify the fact that
-        /// corresponds to this predicate through the p_to_fact_map.
-        /// @param p_expr The fact's head (the destination predicate of the interface constraint).
-        /// @param theory The theory of the source predicate of the interface constraint.
-        void add_predicate_fact(z3::func_decl const& key, z3::expr const& p_expr, Theory theory);
 
         /// @brief Checks the signedness consistency of the clause analysis result.
         /// @param clause_analysis The clause analysis result to check.
@@ -111,8 +95,7 @@ namespace multi_theory_horn {
         //--------------------------------------------------------------------------
         // Construction / destruction
         //--------------------------------------------------------------------------
-        explicit MT_fixedpoint(z3::context& ctx, bool is_signed, unsigned bv_size, bool int2bv_preprocess = true, bool simplify = true);
-        explicit MT_fixedpoint(z3::context& ctx, bool int2bv_preprocess = true, bool simplify = true);
+        explicit MT_fixedpoint(z3::context& ctx, bool force_preprocess = false, bool simplify = true);
 
         /// @brief Initializes the multi-theory fixedpoint engine from
         /// an existing BV fixedpoint engine.
@@ -120,61 +103,21 @@ namespace multi_theory_horn {
         void from_solver(z3::fixedpoint& fp);
 
         //--------------------------------------------------------------------------
-        // Quick access to the underlying fixedpoint engine
-        //--------------------------------------------------------------------------
-        z3::fixedpoint& engine_int()    { return m_fp_int; }
-        z3::fixedpoint& engine_bv()     { return m_fp_bv; }
-
-        //--------------------------------------------------------------------------
-        // Re-implemented / enhanced queries
-        //--------------------------------------------------------------------------
-        /// \brief The query method for the multi-theory fixedpoint engine.
-        /// The query should be over theory2 as the second theory
-        /// is our starting point of the "backward" query algorithm.
-        /// \param vars The vector of variables to be used in the query.
-        /// \param q_pred The predicate in the body of the query.
-        /// \param q_phi The formula to be queried.
-        /// \param theory The theory indicating the engine to which the query belongs.
-        z3::check_result query(z3::expr_vector& vars, z3::expr& q_pred, z3::expr& q_phi, Theory theory);
-
-        /// \brief The query method for the multi-theory fixedpoint engine.
-        /// \param query The query expression.
-        /// \return The result of the query.
-        z3::check_result query(z3::expr& query);
-
-        //--------------------------------------------------------------------------
         // Forwarding of fixepoint most common calles
         //--------------------------------------------------------------------------
         
-        /// \brief Add a rule to the appropriate fixedpoint engine.
-        /// \param rule The rule to add.
-        /// \param theory The theory indicating the engine to which the rule belongs.
-        void add_rule(z3::expr& rule, Theory theory, z3::symbol const& name);
+        /// @brief Add a rule to the appropriate fixedpoint engine.
+        /// @param rule The rule to add.
+        /// @param name The name of the rule.
+        void add_rule(z3::expr& rule, z3::symbol const& name);
 
-        /// \brief Register a relation (predicate) in the appropriate fixedpoint engine.
-        /// \param p The predicate to register.
-        /// \param theory The theory indicating the engine to which the predicate belongs.
-        void register_relation(z3::func_decl& p, Theory theory);
+        /// @brief Register a relation (predicate) in the appropriate fixedpoint engine.
+        /// @param p The predicate to register.
+        void register_relation(z3::func_decl& p);
 
-        //--------------------------------------------------------------------------
-        // Extra methods for multi-theory fixedpoint
-        //--------------------------------------------------------------------------
-        
-        /// @brief Adds an interface constraint (mapping) between two predicates
-        /// in different theories.
-        /// @param p1_expr The source predicate.
-        /// @param theory_1 The theory of the source predicate.
-        /// @param p2_expr The target predicate.
-        /// @param theory_2 The theory of the target predicate.
-        /// @note It's required to pass the expresion of the predicate to also
-        /// be able to extract the variables used in each predicate.
-        void add_interface_constraint(z3::expr p1_expr, Theory theory_1, 
-                                      z3::expr p2_expr, Theory theory_2);
-
+        /// @brief The query method for the multi-theory fixedpoint engine.
+        /// @param query The query expression.
+        /// @return The result of the query.
+        z3::check_result query(z3::expr& query);
     };
-
-    inline std::ostream & operator<<(std::ostream & out, MT_fixedpoint f) { 
-        return out << "Integer Fixedpoint:\n" << f.engine_int() << "\n\n"
-                    << "Bit-vector Fixedpoint:\n" << f.engine_bv();
-    }
 } // namespace multi_theory_horn


### PR DESCRIPTION
- add_rule: Analyzes a newly added rule.

- register_relation: Empty implemenation as predicates are registered to the appropriate solver only after the global signdness is known.

Got rid off the explicit add_interface_constraint