### PR TITLE
[AMTH] Add OverflowAnalysis class

### DIFF
--- a/src/Bv2IntTranslator.cpp
+++ b/src/Bv2IntTranslator.cpp
@@ -2,6 +2,7 @@
 
 #include "Bv2IntTranslator.h"
 
+#define LDBG(x) DEBUG_MSG(OUT() << "[Bv2IntTranslator] " << x)
 namespace multi_theory_horn {
 
     Bv2IntTranslator::Bv2IntTranslator(z3::context& c, bool is_signed, 

--- a/src/Int2BvOverflowAnalyzer.cpp
+++ b/src/Int2BvOverflowAnalyzer.cpp
@@ -1,0 +1,111 @@
+#include "Int2BvOverflowAnalyzer.h"
+
+#define LDBG(x) DEBUG_MSG(OUT() << "[OverflowAnalyzer] " << x)
+
+namespace multi_theory_horn {
+
+    static bool is_const_variable(const z3::expr& e) {
+        // Check if the expression is a variable (0-arity application)
+        return e.is_const() && !e.is_numeral() && !e.is_bool();
+    }
+
+    static bool is_func_app(Z3_decl_kind k) {
+        return (k == Z3_OP_ADD || k == Z3_OP_SUB ||
+                k == Z3_OP_MUL || k == Z3_OP_UMINUS ||
+                k == Z3_OP_DIV || k == Z3_OP_IDIV);
+    }
+
+    Int2BvOverflowAnalyzer::Int2BvOverflowAnalyzer(z3::context& ctx) : 
+        m_ctx(ctx),
+        m_exists_const_out_of_bounds(false),
+        m_var_in_bound_lemmas(ctx),
+        m_func_out_of_bound_lemmas(ctx) {}
+
+    void Int2BvOverflowAnalyzer::reset() {
+        m_exists_const_out_of_bounds = false;
+        m_var_in_bound_lemmas = z3::expr_vector(m_ctx);
+        m_func_out_of_bound_lemmas = z3::expr_vector(m_ctx);
+        m_handled_vars.clear();
+    }
+
+    z3::expr Int2BvOverflowAnalyzer::create_expr_in_bound_lemma(const z3::expr& e, unsigned bv_size, bool is_signed) const {
+        if (is_signed) {
+            int64_t N = (int64_t)1 << (bv_size - 1);
+            return (e >= m_ctx.int_val(-N)) && (e <= m_ctx.int_val(N - 1));
+        }
+
+        int64_t N = (uint64_t)1 << bv_size;
+        return (e >= m_ctx.int_val(0)) && (e < m_ctx.int_val(N));
+    }
+
+    bool Int2BvOverflowAnalyzer::is_const_in_bounds(const z3::expr& e, unsigned bv_size, bool is_signed) const {
+        assert(e.is_numeral() && "Expected a constant expression");
+        if (is_signed) {
+            int64_t lower_bound = utils::get_signed_bv_lower_bound(bv_size);
+            int64_t upper_bound = utils::get_signed_bv_upper_bound(bv_size);
+            return e.get_numeral_int64() >= lower_bound && e.get_numeral_int64() <= upper_bound;
+        }
+
+        uint64_t lower_bound = utils::get_unsigned_bv_lower_bound(bv_size);
+        uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(bv_size);
+        return static_cast<uint64_t>(e.get_numeral_int64()) >= lower_bound && static_cast<uint64_t>(e.get_numeral_int64()) < upper_bound;
+    }
+
+    void Int2BvOverflowAnalyzer::populate_bound_lemmas(const z3::expr& e, unsigned bv_size_vars, unsigned bv_size_funcs_consts,
+                                                       bool is_signed_vars, bool is_signed_funcs_consts) {
+        if (m_exists_const_out_of_bounds) {
+            // If we already found a constant out of bounds, no need to continue checking
+            return;
+        }
+        if (e.is_true() || e.is_false()) {
+            return;
+        }
+        else if (e.is_numeral()) {
+            bool in_bounds = is_const_in_bounds(e, bv_size_funcs_consts, is_signed_funcs_consts);
+            m_exists_const_out_of_bounds |= !in_bounds;
+        }
+        else if (is_const_variable(e) && 
+                    m_handled_vars.find((Z3_ast)e) == m_handled_vars.end()) {
+            // Add the variable to the cache if not already handled
+            m_handled_vars.insert((Z3_ast)e);
+            // Add the lemma: var >= -2^(n-1) && var < 2^(n-1)
+            z3::expr var_bound_expr = create_expr_in_bound_lemma(e, bv_size_vars, is_signed_vars);
+            m_var_in_bound_lemmas.push_back(var_bound_expr);
+        }
+        else {
+            if (is_func_app(e.decl().decl_kind())) {
+                // Add the lemma: func(arg1, arg2, ...) < -2^(n-1) || func(arg1, arg2, ...) >= 2^(n-1)
+                z3::expr func_bound_expr = create_expr_in_bound_lemma(e, bv_size_funcs_consts, is_signed_funcs_consts);
+                m_func_out_of_bound_lemmas.push_back(!func_bound_expr);
+            }
+        }
+
+        for (unsigned i = 0; i < e.num_args(); ++i) {
+            populate_bound_lemmas(e.arg(i), bv_size_vars, bv_size_funcs_consts, is_signed_vars, is_signed_funcs_consts);
+        }
+    }
+
+    bool Int2BvOverflowAnalyzer::overflows(const z3::expr& e, unsigned bv_size_vars,
+                                           unsigned bv_size_funcs_consts, bool is_signed_vars,
+                                           bool is_signed_funcs_consts) {
+        assert(!(is_signed_vars && !is_signed_funcs_consts) && "If variables are signed, expressions must be treated as signed");
+        populate_bound_lemmas(e, bv_size_vars, bv_size_funcs_consts, is_signed_vars, is_signed_funcs_consts);
+        if (m_exists_const_out_of_bounds) {
+            LDBG("Constant out of bounds detected" << std::endl);
+            return true;
+        }
+
+        // Create the overflow formula and check if it's satisfiable or not
+        z3::expr formula = z3::mk_and(m_var_in_bound_lemmas) && z3::mk_or(m_func_out_of_bound_lemmas);
+        z3::solver s(m_ctx);
+        s.add(formula);
+        LDBG("Overflow formula: " << formula << "\n");
+        if (s.check() == z3::sat) {
+            return true;
+        }
+
+        assert(s.check() != z3::unknown && "Solver returned unknown when checking for overflow");
+        return false;
+    }
+
+} // namespace multi_theory_horn

--- a/src/Int2BvOverflowAnalyzer.h
+++ b/src/Int2BvOverflowAnalyzer.h
@@ -1,0 +1,29 @@
+
+
+#pragma once
+#include "utils.h"
+#include "mth_utils.h"
+#include <z3++.h>
+#include <unordered_set>
+
+namespace multi_theory_horn {
+    class Int2BvOverflowAnalyzer {
+        z3::context& m_ctx;
+        bool m_exists_const_out_of_bounds;
+        z3::expr_vector m_var_in_bound_lemmas;
+        z3::expr_vector m_func_out_of_bound_lemmas;
+
+        using VarCache = std::unordered_set<Z3_ast, AstHash, AstEq>;
+        VarCache m_handled_vars;
+
+        z3::expr create_expr_in_bound_lemma(const z3::expr& e, unsigned bv_size, bool is_signed) const;
+        bool is_const_in_bounds(const z3::expr& e, unsigned bv_size, bool is_signed) const;
+        void populate_bound_lemmas(const z3::expr& e, unsigned bv_size_vars, unsigned bv_size_funcs_consts,
+                                    bool is_signed_vars, bool is_signed_funcs_consts);
+    public:
+        Int2BvOverflowAnalyzer(z3::context& ctx);
+        void reset();
+        bool overflows(const z3::expr& e, unsigned bv_size_vars, unsigned bv_size_funcs_consts,
+                        bool is_signed_vars, bool is_signed_funcs_consts);
+    };
+}

--- a/src/Int2BvPreprocessor.cpp
+++ b/src/Int2BvPreprocessor.cpp
@@ -2,10 +2,9 @@
 
 #define PREPROCESSOR_DEBUG 1
 #if PREPROCESSOR_DEBUG
-  #define PRE_DEBUG(x) \
-    DEBUG_MSG(OUT() << "[PREPROCESSOR] " << x)
+  #define LDBG(x) DEBUG_MSG(OUT() << "[PREPROCESSOR] " << x)
 #else
-  #define PRE_DEBUG(x) do {} while (0)
+  #define LDBG(x) do {} while (0)
 #endif
 
 namespace multi_theory_horn {
@@ -73,8 +72,7 @@ namespace multi_theory_horn {
         m_ctx(c),
         m_bv_size(bv_size),
         m_is_signed(is_signed),
-        m_vars_bound_lemmas(c),
-        m_bv_size_extended(bv_size)
+        m_vars_bound_lemmas(c)
     {}
 
     void Int2BvPreprocessor::reset() {
@@ -95,12 +93,12 @@ namespace multi_theory_horn {
         z3::expr res(m_ctx);
 
         if (m_is_signed) {
-            int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size_extended);
+            int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size);
             switch (e_kind) {
                 case Z3_OP_ADD:
                 case Z3_OP_SUB:
                 case Z3_OP_MUL:
-                    res = !create_arith_bounds_expr(e);
+                    res = !create_bounds_expr(e);
                     break;
                 case Z3_OP_UMINUS:
                     res = (e.arg(0) == m_ctx.int_val(lower_bound));
@@ -114,7 +112,7 @@ namespace multi_theory_horn {
             }
         }
         else {
-            uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(m_bv_size_extended);
+            uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(m_bv_size);
             switch (e_kind) {
                 case Z3_OP_ADD:
                     res = (e > m_ctx.int_val(upper_bound));
@@ -152,25 +150,27 @@ namespace multi_theory_horn {
         }
     }
 
-    z3::expr Int2BvPreprocessor::create_arith_bounds_expr(const z3::expr& term) const {
-        int64_t N = (int64_t)1 << (m_bv_size_extended - 1);
-        return (term >= m_ctx.int_val(-N)) && (term <= m_ctx.int_val(N - 1));
-    }
-
-    z3::expr Int2BvPreprocessor::create_var_bounds_expr(const z3::expr& var) const {
+    z3::expr Int2BvPreprocessor::create_bounds_expr(const z3::expr& term) const {
         if (m_is_signed) {
             int64_t N = (int64_t)1 << (m_bv_size - 1);
-            return (var >= m_ctx.int_val(-N)) && (var <= m_ctx.int_val(N - 1));
+            return (term >= m_ctx.int_val(-N)) && (term <= m_ctx.int_val(N - 1));
         }
 
         int64_t N = (uint64_t)1 << m_bv_size;
-        return (var >= m_ctx.int_val(0)) && (var <= m_ctx.int_val(N - 1));
+        return (term >= m_ctx.int_val(0)) && (term <= m_ctx.int_val(N - 1));
     }
 
     bool Int2BvPreprocessor::is_const_in_bounds(const z3::expr& const_e) const {
         assert(const_e.is_numeral() && "Expected a constant expression");
-        int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size_extended);
-        int64_t upper_bound = utils::get_signed_bv_upper_bound(m_bv_size_extended);
+        if (m_is_signed) {
+            int64_t lower_bound = utils::get_signed_bv_lower_bound(m_bv_size);
+            int64_t upper_bound = utils::get_signed_bv_upper_bound(m_bv_size);
+            return const_e.get_numeral_int64() >= lower_bound && const_e.get_numeral_int64() <= upper_bound;
+        }
+
+        uint64_t upper_bound = utils::get_unsigned_bv_upper_bound(m_bv_size);
+        uint64_t lower_bound = utils::get_unsigned_bv_lower_bound(m_bv_size);
+        assert(m_bv_size <= 64 && "Unexpected bv size");
         return const_e.get_numeral_int64() >= lower_bound && const_e.get_numeral_int64() <= upper_bound;
     }
 
@@ -218,7 +218,7 @@ namespace multi_theory_horn {
                  m_handled_vars.find((Z3_ast)literal) == m_handled_vars.end()) {
             // Add the variable to the cache if not already handled
             m_handled_vars.insert((Z3_ast)literal);
-            z3::expr var_bound_expr = create_var_bounds_expr(literal);
+            z3::expr var_bound_expr = create_bounds_expr(literal);
             m_vars_bound_lemmas.push_back(var_bound_expr);
         }
         else {
@@ -376,46 +376,27 @@ namespace multi_theory_horn {
         return create_UNSAT_out_of_bounds_expr(e);
     }
 
-    bool Int2BvPreprocessor::overflows(const z3::expr& e, unsigned extended_size) {
-        m_bv_size_extended = extended_size;
-        InstCombiner combiner = InstCombiner(m_ctx);
-        // Help the preprocessor by optimizing the expressions
-        // to more "friendly" forms
-        z3::expr e_opt = combiner.combine(e);
-        PRE_DEBUG("Combined input: " << e_opt << "\n");
-
-        // Assume input is in CNF
-        populate_data_structures(e_opt);
-        z3::expr psi = create_SAT_out_of_bounds_expr(e_opt);
-        PRE_DEBUG("psi (SATOutOfBounds): " << psi << "\n");
-        z3::expr psi_tag = create_UNSAT_out_of_bounds_expr(e_opt);
-        PRE_DEBUG("psi_tag (UNSATOutOfBounds): " << psi_tag << "\n");
-
-        // If both psi and psi_tag are false, then there is no overflow
-        return !(psi.is_false() && psi_tag.is_false());
-    }
-
     z3::expr Int2BvPreprocessor::preprocess(const z3::expr& e) {
         InstCombiner combiner = InstCombiner(m_ctx);
         // Help the preprocessor by optimizing the expressions
         // to more "friendly" forms
         z3::expr e_opt = combiner.combine(e);
-        PRE_DEBUG("Combined input: " << e_opt << "\n");
+        LDBG("Combined input: " << e_opt << "\n");
         // Assume input is in CNF
         populate_data_structures(e_opt);
         z3::expr psi = create_SAT_out_of_bounds_expr(e_opt);
-        PRE_DEBUG("psi (SATOutOfBounds): " << psi << "\n");
+        LDBG("psi (SATOutOfBounds): " << psi << "\n");
         z3::expr psi_tag = create_UNSAT_out_of_bounds_expr(e_opt);
-        PRE_DEBUG("psi_tag (UNSATOutOfBounds): " << psi_tag << "\n");
+        LDBG("psi_tag (UNSATOutOfBounds): " << psi_tag << "\n");
 
         z3::expr psi_SAT = create_psi_expr(psi);
-        PRE_DEBUG("psi_SAT: " << psi_SAT << "\n");
+        LDBG("psi_SAT: " << psi_SAT << "\n");
         z3::expr psi_UNSAT = create_psi_expr(psi_tag);
-        PRE_DEBUG("psi_UNSAT: " << psi_UNSAT << "\n");
+        LDBG("psi_UNSAT: " << psi_UNSAT << "\n");
         z3::expr phi_1 = drop_out_of_bounds_literals(e_opt);
-        PRE_DEBUG("phi_1: " << phi_1 << "\n");
+        LDBG("phi_1: " << phi_1 << "\n");
         z3::expr phi_2 = (phi_1 && !psi_UNSAT) || psi_SAT;
-        PRE_DEBUG("phi_2: " << phi_2 << "\n");
+        LDBG("phi_2: " << phi_2 << "\n");
 
         return better_simplify(phi_2);
     }

--- a/src/Int2BvPreprocessor.h
+++ b/src/Int2BvPreprocessor.h
@@ -17,10 +17,6 @@ namespace multi_theory_horn {
         unsigned m_bv_size;
         bool m_is_signed;
 
-        // The bit-vector size used to check if the expression
-        // overflows. The extended size is by default equal to m_bv_size.
-        unsigned m_bv_size_extended;
-
         using ExprVectorMatrix = std::vector<std::vector<z3::expr_vector>>;
         using LiteralMatrix = std::vector<std::vector<z3::expr>>;
         using boolMatrix = std::vector<std::vector<bool>>;
@@ -36,17 +32,12 @@ namespace multi_theory_horn {
         ExprVectorMatrix m_func_app_out_of_bounds;
         LiteralMatrix m_literals;
 
-
-        // Returns the number of conjuncts in an expression
-        int calc_num_of_conjuncts(const z3::expr& e) const;
-        int calc_num_of_disjuncts(const z3::expr& e) const;
         int get_num_of_conjuncts() const;
         int get_num_of_disjuncts(int conjunct) const;
 
         bool is_const_variable(const z3::expr& e) const;
 
-        z3::expr create_arith_bounds_expr(const z3::expr& term) const;
-        z3::expr create_var_bounds_expr(const z3::expr& var) const;
+        z3::expr create_bounds_expr(const z3::expr& term) const;
         bool is_const_in_bounds(const z3::expr& const_e) const;
         z3::expr create_term_out_of_bounds_expr(const z3::expr& e) const;
 
@@ -81,11 +72,6 @@ namespace multi_theory_horn {
         z3::expr create_SAT_out_of_bounds(const z3::expr& e);
         z3::expr create_UNSAT_out_of_bounds(const z3::expr& e);
 
-        // A function that checks whether the given expression requires preprocessing
-        // for overflow/underflow when using the given extended bit-vector size.
-        // We might have a case that doesn't require preprocessing for bv_size
-        // larger than the base size.
-        bool overflows(const z3::expr& e, unsigned extended_size);
         z3::expr preprocess(const z3::expr& e);
     };
 } // namespace multi_theory_horn

--- a/src/Int2BvTranslator.cpp
+++ b/src/Int2BvTranslator.cpp
@@ -2,6 +2,8 @@
 
 #include "Int2BvTranslator.h"
 
+#define LDBG(x) DEBUG_MSG(OUT() << "[Int2BvTranslator] " << x)
+
 namespace multi_theory_horn {
 
     Int2BvTranslator::Int2BvTranslator(z3::context& c, bool is_signed, unsigned bv_size,
@@ -214,6 +216,39 @@ namespace multi_theory_horn {
         return e.decl()(new_args);
     }
 
+    void Int2BvTranslator::determine_extension_config(const z3::expr& e) {
+        Int2BvOverflowAnalyzer oa(ctx);
+        unsigned extended_size = 0;
+        if (m_is_signed) {
+            for (unsigned d = 0; d <= MAX_MTH_BV_SIZE - m_bv_size; ++d) {
+                extended_size = m_bv_size + d;
+                if (!oa.overflows(e, /*bv_size_vars*/ m_bv_size, /*bv_size_funcs_consts*/ extended_size, /*is_signed_vars*/ true, /*is_signed_func_consts*/ true)) {
+                    break;
+                }
+                oa.reset();
+            }
+        }
+        else {
+            for (unsigned d = 0; d <= MAX_MTH_BV_SIZE - m_bv_size; ++d) {
+                extended_size = m_bv_size + d;
+                if (d == 0) {
+                    if (!oa.overflows(e, /*bv_size_vars*/ m_bv_size, /*bv_size_funcs_consts*/ extended_size, /*is_signed_vars*/ false, /*is_signed_func_consts*/ false))
+                        break;
+                }
+                else if (!oa.overflows(e, /*bv_size_vars*/ m_bv_size, /*bv_size_funcs_consts*/ extended_size, /*is_signed_vars*/ false, /*is_signed_func_consts*/ true)) {
+                    // Translate to signed bit-vectors when extended even though
+                    // originally unsigned
+                    m_is_signed = true;
+                    break;
+                }
+                oa.reset();
+            }
+        }
+
+        assert(extended_size <= MAX_MTH_BV_SIZE && "Exceeded maximum bit-vector size extension");
+        m_extended_bv_size = extended_size;
+    }
+
     z3::expr Int2BvTranslator::translate(const z3::expr& e, bool handle_overflow) {
         if (!handle_overflow)
             return translate_aux(e);
@@ -222,25 +257,14 @@ namespace multi_theory_horn {
         z3::expr expr_to_translate = e;
         if (m_force_preprocess) {
             expr_to_translate = preprocessor.preprocess(e);
-            DEBUG_MSG(OUT() << "Preprocessed expr: " << expr_to_translate << "\n");
+            LDBG("Preprocessed expr: " << expr_to_translate << "\n");
         }
         else {
             // We try to avoid preprocessing here by translating to larger
             // bit-vectors only if necessary.
             // Set the extended bv size based on the signedness.
-            m_extended_bv_size = m_is_signed ? m_bv_size - 1 : m_bv_size;
-            bool requires_extension = false;
-            do {
-                m_extended_bv_size += 1;
-                DEBUG_MSG(OUT() << "Checking if phi requires extension for bv size "
-                                << m_extended_bv_size << std::endl);
-                requires_extension = preprocessor.overflows(e, m_extended_bv_size);
-            } while (requires_extension);
-
-            // In this case, always translate as though we translating
-            // signed expressions.
-            m_is_signed = true;
-            assert(m_extended_bv_size <= MAX_MTH_BV_SIZE && "Exceeded maximum bit-vector size extension");
+            determine_extension_config(e);
+            LDBG("Determined extended BV size: " << m_extended_bv_size << "\n");
         }
 
         return translate_aux(expr_to_translate);

--- a/src/Int2BvTranslator.h
+++ b/src/Int2BvTranslator.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "utils.h"
 #include "Int2BvPreprocessor.h"
+#include "Int2BvOverflowAnalyzer.h"
 #include <iostream>
 #include <z3++.h>
 #include <unordered_map>
@@ -44,6 +45,8 @@ namespace multi_theory_horn {
         bool is_basic(const z3::expr& e) const;
         bool is_int_relation(const z3::expr& e) const;
 
+        void determine_extension_config(const z3::expr& e);
+
         // Core translation routines
         z3::expr translate_int(const z3::expr& e);
         z3::expr translate_basic(const z3::expr& e);
@@ -63,7 +66,7 @@ namespace multi_theory_horn {
         void reset();
 
         // Translate any expr; caches results in m_translate
-        z3::expr translate(const z3::expr& e, bool handle_overflow = false);
+        z3::expr translate(const z3::expr& e, bool handle_overflow = true);
         
         // Accessors for the collected vars
         const z3::expr_vector& vars() const { return m_vars; }

--- a/src/multi_theory_fixedpoint.cpp
+++ b/src/multi_theory_fixedpoint.cpp
@@ -601,7 +601,7 @@ namespace multi_theory_horn {
                     else {
                         unsigned bv_size = current_solver->get_bv_size();
                         Int2BvTranslator int2bv_t(m_ctx, is_signed /*is_signed*/, bv_size, /*force_preprocess*/ m_int2bv_preprocess, m_simplify, var_map);
-                        p_interp_trans = int2bv_t.translate(p_interp, /*handle_overflow*/ true);
+                        p_interp_trans = int2bv_t.translate(p_interp);
                     }
                     DEBUG_MSG(OUT() << "Translated interpretation of " << p_decl.name() << ":\n" << p_interp_trans << std::endl);
 
@@ -674,8 +674,8 @@ namespace multi_theory_horn {
                         translated_vars = bv2int_t.vars();
                     } else {
                         unsigned bv_size = current_solver->get_bv_size();
-                        Int2BvTranslator int2bv_t(m_ctx, true /*is_signed*/, bv_size, /*force_preprocess*/ m_int2bv_preprocess, m_simplify);
-                        phi_trans = int2bv_t.translate(phi, /*handle_overflow*/ true);
+                        Int2BvTranslator int2bv_t(m_ctx, is_signed /*is_signed*/, bv_size, /*force_preprocess*/ m_int2bv_preprocess, m_simplify);
+                        phi_trans = int2bv_t.translate(phi);
                         translated_vars = int2bv_t.vars();
                     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -25,12 +25,13 @@ namespace utils {
     }
 
     int64_t sign_extend(uint64_t raw, unsigned width) {
+        assert(width > 0 && width <= 63);
         // keep only the low 'width' bits
-        int64_t mask = (1 << width) - 1;
+        uint64_t mask = (1ULL << width) - 1;
         int64_t u    = raw & mask;
         // if top bit set, subtract 2^width
-        if (u & (1 << (width-1)))
-            u -= (1 << width);
+        if (u & (1ULL << (width - 1)))
+            u -= (1ULL << width);
         return u;
     }
 


### PR DESCRIPTION
This commit comes with an effort to not use the preprocessor with its heavy calcultions when translating int2bv.
The strategy is that we check if there's an overflow in the expression we want to translate, and if yes, we translate to an extended bv-size where there's no overflow.

This commit also removes all the workarounds that exist in the preprocessor class and completely separates the overflow analysis to a different class.